### PR TITLE
Fix edit install failing due to missing sudo and zstd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	bat \
 	fzf \
 	nano \
+	zstd \
 	zoxide \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& ln -s $(which fdfind) /usr/local/bin/fd \

--- a/setup.sh
+++ b/setup.sh
@@ -203,14 +203,12 @@ install_edit() {
 	echo "Installing Edit v${EDIT_VERSION}..."
 	ARCH=$(uname -m)
 	if [ "$ARCH" = "aarch64" ]; then ZARCH="aarch64"; else ZARCH="x86_64"; fi
-	sudo apt-get update -qq && sudo apt-get install -y -qq zstd >/dev/null 2>&1
 	curl -fsSLo /tmp/edit.tar.zst "https://github.com/microsoft/edit/releases/download/v${EDIT_VERSION}/edit-${EDIT_ASSET_VERSION}-${ZARCH}-linux-gnu.tar.zst"
 	verify_checksum /tmp/edit.tar.zst "edit-${EDIT_ASSET_VERSION}-${ZARCH}-linux-gnu.tar.zst"
 	zstd -d /tmp/edit.tar.zst -o /tmp/edit.tar
 	tar xf /tmp/edit.tar -C /tmp
 	find /tmp -name 'edit' -type f -executable -exec mv {} ~/.local/bin/edit \;
 	rm -f /tmp/edit.tar.zst /tmp/edit.tar
-	sudo apt-get purge -y -qq --auto-remove zstd >/dev/null 2>&1
 }
 
 install_fresh() {


### PR DESCRIPTION
## Summary
- `install_edit()` in `setup.sh` called `sudo apt-get install zstd`, but the container runs as non-root with no `sudo` available
- Moved `zstd` into the Dockerfile base apt packages so it's pre-installed in the image
- Removed the `sudo apt-get install/purge zstd` lines from `setup.sh` since they're no longer needed

## Test plan
- [ ] Rebuild the Docker image (`docker build -t squarebox .`)
- [ ] Run setup and select Edit as the simple text editor — verify it installs without errors
- [ ] Confirm `edit` launches correctly inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)