### PR TITLE
Fix /workspace ownership issue from volume mounts

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -13,7 +13,20 @@ SETUP_CHECKSUMS="${HOME}/setup-checksums.txt"
 
 # Fix /workspace ownership if volume mount left it owned by a different UID
 if [ -d /workspace ] && ! [ -w /workspace ]; then
-	sudo chown dev:dev /workspace
+	if ! command -v sudo >/dev/null 2>&1; then
+		echo "ERROR: /workspace is not writable and sudo is not available to fix ownership." >&2
+		echo "Please make /workspace writable for user 'dev' or rerun with appropriate privileges." >&2
+		exit 1
+	elif ! sudo -n true >/dev/null 2>&1; then
+		echo "ERROR: /workspace is not writable and passwordless sudo is required to fix ownership automatically." >&2
+		echo "Please run 'sudo chown dev:dev /workspace' manually or rerun with appropriate privileges." >&2
+		exit 1
+	elif ! sudo -n chown dev:dev /workspace; then
+		echo "ERROR: Failed to change ownership of /workspace to dev:dev." >&2
+		echo "This can happen on volume types that do not allow chown." >&2
+		echo "Please make /workspace writable for user 'dev' or adjust the mount configuration and try again." >&2
+		exit 1
+	fi
 fi
 
 # Verify SHA256 checksum of a downloaded file against the checksums file.


### PR DESCRIPTION
## Summary
Added a setup check to fix `/workspace` directory ownership when it's left owned by a different UID after volume mounting, ensuring the `dev` user has write access.

## Changes
- Added ownership verification and correction logic in `setup.sh` that runs before other setup operations
- Checks if `/workspace` directory exists and is not writable by the current user
- Automatically corrects ownership to `dev:dev` using `sudo chown` when needed

## Details
This addresses a common issue where Docker/container volume mounts can leave directories owned by a different UID (often root or the host user), preventing the `dev` user from writing to `/workspace`. The fix runs early in the setup process to ensure the workspace is properly accessible before any subsequent operations that may need to write to it.

https://claude.ai/code/session_01TR9J29vjg68mu152ZxK8V8