### PR TITLE
install: fix alias/function parse collision and PS profile discovery

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,20 +65,46 @@ jobs:
           test -d "$INSTALL_DIR/workspace"
           echo "PASS: 1.3 workspace directory created"
 
-      - name: "1.4 Shell aliases generation"
+      - name: "1.4 Shell integration generation"
         run: |
-          SHELL_RC=$(mktemp)
-          # Simulate alias insertion logic from install.sh
-          echo "alias sqrbx='docker start -ai squarebox'" >> "$SHELL_RC"
-          echo "alias squarebox='docker start -ai squarebox'" >> "$SHELL_RC"
-          echo "alias sqrbx-rebuild='~/squarebox/install.sh'" >> "$SHELL_RC"
-          echo "alias squarebox-rebuild='~/squarebox/install.sh'" >> "$SHELL_RC"
+          # Verify install.sh's shell-integration block by running it against a
+          # fixture rc file that contains legacy cruft from pre-646a589 installs.
+          # Regression guard for the "alias shadows function ⇒ parse error" bug.
+          export HOME="$(mktemp -d)"
+          export USER_HOME="$HOME"
+          SHELL_RC="$HOME/.bashrc"
+          cat > "$SHELL_RC" <<'LEGACY'
+          # Existing user content
+          alias ll='ls -la'
+          # Junk from an older install.sh
+          alias sqrbx='docker start -ai squarebox'
+          alias squarebox='docker start -ai squarebox'
+          alias sqrbx-rebuild='~/squarebox/install.sh'
+          alias squarebox-rebuild='~/squarebox/install.sh'
+          sqrbx() { if command -v winpty &>/dev/null && [[ -n "${MSYSTEM:-}" ]]; then winpty docker start -ai squarebox; else docker start -ai squarebox; fi; }
+          LEGACY
 
-          grep -q 'alias sqrbx=' "$SHELL_RC" || { echo "FAIL: sqrbx alias"; exit 1; }
-          grep -q 'alias squarebox=' "$SHELL_RC" || { echo "FAIL: squarebox alias"; exit 1; }
-          grep -q 'alias sqrbx-rebuild=' "$SHELL_RC" || { echo "FAIL: sqrbx-rebuild alias"; exit 1; }
-          grep -q 'alias squarebox-rebuild=' "$SHELL_RC" || { echo "FAIL: squarebox-rebuild alias"; exit 1; }
-          echo "PASS: all 4 aliases present"
+          # Run the exact shell-integration block from install.sh against the fixture.
+          # Extract lines from "# Shell config must go" through the syntax-check block.
+          awk '/^# Shell config must go/{f=1} f{print; if (/^# end squarebox shell integration$/) exit}' install.sh > /tmp/shell_block.sh
+          bash /tmp/shell_block.sh
+
+          # Assertions
+          test -f "$HOME/.squarebox-shell-init" || { echo "FAIL: init file not created"; exit 1; }
+          grep -q '^sqrbx() {' "$HOME/.squarebox-shell-init" || { echo "FAIL: sqrbx function missing"; exit 1; }
+          grep -q '^# >>> squarebox >>>' "$SHELL_RC" || { echo "FAIL: sentinel block missing from rc"; exit 1; }
+          grep -q 'squarebox-shell-init' "$SHELL_RC" || { echo "FAIL: rc does not source init file"; exit 1; }
+          grep -q "^alias sqrbx=" "$SHELL_RC" && { echo "FAIL: legacy alias not scrubbed"; exit 1; }
+          grep -q "^sqrbx() {" "$SHELL_RC" && { echo "FAIL: legacy one-liner function not scrubbed"; exit 1; }
+          grep -q "^alias ll=" "$SHELL_RC" || { echo "FAIL: unrelated user content removed"; exit 1; }
+          bash -n "$SHELL_RC" || { echo "FAIL: rc fails bash -n after edit"; exit 1; }
+          bash -O expand_aliases -i -c "source '$SHELL_RC'; type sqrbx | grep -q function" </dev/null || { echo "FAIL: sqrbx not a function after source"; exit 1; }
+
+          # Idempotency
+          bash /tmp/shell_block.sh
+          [ "$(grep -c '^# >>> squarebox >>>' "$SHELL_RC")" = 1 ] || { echo "FAIL: sentinel block duplicated on re-run"; exit 1; }
+
+          echo "PASS: shell integration managed block generated and idempotent"
 
       - name: "1.6 Host configs seeded"
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -70,8 +70,18 @@ jobs:
           # Verify install.sh's shell-integration block by running it against a
           # fixture rc file that contains legacy cruft from pre-646a589 installs.
           # Regression guard for the "alias shadows function ⇒ parse error" bug.
+          #
+          # The fixture deliberately sets HOME and USER_HOME to DIFFERENT temp
+          # dirs to simulate the Git Bash scenario (HOME=/home/user vs
+          # USER_HOME=C:/Users/...). This catches regressions where install.sh
+          # confuses the two — the init file must land under HOME (where the
+          # shell looks for it) while the install dir lives under USER_HOME
+          # and must be baked into sqrbx-rebuild at install time.
           export HOME="$(mktemp -d)"
-          export USER_HOME="$HOME"
+          export USER_HOME="$(mktemp -d)"
+          export INSTALL_DIR="$USER_HOME/squarebox"
+          mkdir -p "$INSTALL_DIR"
+          cp install.sh "$INSTALL_DIR/install.sh"
           SHELL_RC="$HOME/.bashrc"
           cat > "$SHELL_RC" <<'LEGACY'
           # Existing user content
@@ -89,9 +99,17 @@ jobs:
           awk '/^# Shell config must go/{f=1} f{print; if (/^# end squarebox shell integration$/) exit}' install.sh > /tmp/shell_block.sh
           bash /tmp/shell_block.sh
 
-          # Assertions
-          test -f "$HOME/.squarebox-shell-init" || { echo "FAIL: init file not created"; exit 1; }
+          # Assertions — init file lives under HOME, not USER_HOME
+          test -f "$HOME/.squarebox-shell-init" || { echo "FAIL: init file not created under HOME"; exit 1; }
+          test -f "$USER_HOME/.squarebox-shell-init" && { echo "FAIL: init file wrongly created under USER_HOME"; exit 1; }
           grep -q '^sqrbx() {' "$HOME/.squarebox-shell-init" || { echo "FAIL: sqrbx function missing"; exit 1; }
+          # sqrbx-rebuild must reference $INSTALL_DIR (USER_HOME-based), not $HOME
+          grep -qF "\"$INSTALL_DIR/install.sh\"" "$HOME/.squarebox-shell-init" || { echo "FAIL: sqrbx-rebuild does not reference INSTALL_DIR"; exit 1; }
+          grep -q "\$HOME/squarebox/install.sh" "$HOME/.squarebox-shell-init" && { echo "FAIL: sqrbx-rebuild still uses \$HOME/squarebox (HOME != USER_HOME mismatch)"; exit 1; }
+          # Literal $@ and ${MSYSTEM:-} should be preserved in the init file (runtime expansion)
+          grep -q '\$@' "$HOME/.squarebox-shell-init" || { echo "FAIL: \$@ not preserved in init file"; exit 1; }
+          grep -q '\${MSYSTEM:-}' "$HOME/.squarebox-shell-init" || { echo "FAIL: \${MSYSTEM:-} not preserved in init file"; exit 1; }
+
           grep -q '^# >>> squarebox >>>' "$SHELL_RC" || { echo "FAIL: sentinel block missing from rc"; exit 1; }
           grep -q 'squarebox-shell-init' "$SHELL_RC" || { echo "FAIL: rc does not source init file"; exit 1; }
           grep -q "^alias sqrbx=" "$SHELL_RC" && { echo "FAIL: legacy alias not scrubbed"; exit 1; }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,8 @@ The Dockerfile uses `SHELL ["/bin/bash", "-c"]` because `tool-lib.sh` relies on 
 - **PowerShell**: only PowerShell 7+ (`pwsh`) is supported. Windows PowerShell 5.1 (`powershell.exe`) is not supported.
 - **Git Bash**: install.sh uses `MSYS_NO_PATHCONV=1` to prevent MSYS2 path mangling in Docker volume mounts.
 - **Install directory**: uses `USERPROFILE` (not MSYS2 `HOME`) so the clone lands at `C:\Users\<user>\squarebox`.
+- **`$HOME` vs `$USER_HOME`** (install.sh): on Git Bash these diverge — `$HOME` is the MSYS home (`/home/user`, where bash actually reads `.bashrc` from), while `$USER_HOME` is derived from `USERPROFILE` (`C:/Users/user`, where the clone lives). Things anchored to the running shell (rc files, the `~/.squarebox-shell-init` file the sentinel sources) must use `$HOME`; things anchored to the filesystem install (`$INSTALL_DIR`, git config path, volume mounts) use `$USER_HOME`. Baking `$INSTALL_DIR` into shell function bodies at install time avoids runtime `$HOME` resolving wrong. On Linux/macOS the two are identical.
+- **Shell integration**: install.sh writes the four function bodies to `~/.squarebox-shell-init` and adds a single sentinel-marked `. ~/.squarebox-shell-init` line to `~/.bashrc` / `~/.zshrc` / PowerShell `$PROFILE`. The sentinel block (`# >>> squarebox >>>` / `# <<< squarebox <<<`) is scrubbed and rewritten on every run, along with any legacy `alias sqrbx=...` or one-liner `sqrbx() {...}` lines from pre-646a589 installs (those collide with the function definitions at parse time due to `expand_aliases` and produce a `syntax error near unexpected token '('`).
 
 ## Tool Registry
 

--- a/install.sh
+++ b/install.sh
@@ -92,7 +92,8 @@ fi
 
 # Build
 _build_log="$(mktemp)"
-trap 'rm -f "$_build_log"' EXIT
+_rc_tmp=""
+trap 'rm -f "$_build_log" "$_rc_tmp" 2>/dev/null || true' EXIT
 if [ "$VERBOSE" = 1 ]; then
 	echo "Building image..."
 	docker_cmd build -t "$IMAGE_NAME" "$INSTALL_DIR"
@@ -118,33 +119,65 @@ fi
 # Shell config must go where bash/zsh actually reads from ($HOME), which may
 # differ from USER_HOME on standalone MSYS2. The install directory uses
 # USER_HOME so it lands somewhere visible, but shell config is separate.
-case "${SHELL:-}" in
-	*/zsh) SHELL_RC="${HOME}/.zshrc" ;;
-	*)     SHELL_RC="${HOME}/.bashrc" ;;
-esac
-
-# Use shell functions (not aliases) so winpty detection happens at runtime
-# rather than being baked in at install time. This way the same config works
-# regardless of which terminal the user opens (Git Bash, PowerShell, etc.).
-ALIASES_ADDED=false
-
-_add_shell_func() {
-	local name="$1" body="$2"
-	if ! grep -q "^${name}()" "$SHELL_RC" 2>/dev/null; then
-		printf '%s() { %s; }\n' "$name" "$body" >> "$SHELL_RC"
-		ALIASES_ADDED=true
-	fi
-}
-
-_docker_start='if command -v winpty &>/dev/null && [[ -n "${MSYSTEM:-}" ]]; then winpty docker start -ai squarebox; else docker start -ai squarebox; fi'
-_add_shell_func "sqrbx" "$_docker_start"
-_add_shell_func "squarebox" "$_docker_start"
-_add_shell_func "sqrbx-rebuild" "${INSTALL_DIR}/install.sh"
-_add_shell_func "squarebox-rebuild" "${INSTALL_DIR}/install.sh"
-
-if [ "$ALIASES_ADDED" = true ]; then
-	echo "Added squarebox functions to $SHELL_RC — restart your shell or run: source $SHELL_RC"
+# On Git Bash (MSYSTEM set) force .bashrc regardless of $SHELL — if install.sh
+# is re-invoked from a parent PowerShell, $SHELL may be unset or unrelated.
+if [ -n "${MSYSTEM:-}" ]; then
+	SHELL_RC="${HOME}/.bashrc"
+else
+	case "${SHELL:-}" in
+		*/zsh) SHELL_RC="${HOME}/.zshrc" ;;
+		*)     SHELL_RC="${HOME}/.bashrc" ;;
+	esac
 fi
+
+# Write the function bodies to a dedicated file that install.sh overwrites on
+# every run, and reference it from $SHELL_RC via a sentinel one-liner. Mirrors
+# the pattern already used inside the container (see Dockerfile: ~/.squarebox-*
+# aliases sourced from ~/.bashrc). Benefits:
+#  - Future updates just overwrite the init file, no rc-file splicing.
+#  - Legacy `alias sqrbx=...` / `sqrbx() {...}` cruft from older install.sh
+#    versions gets scrubbed on every run — critical because an old alias
+#    shadows the new function definition at parse time (expand_aliases is on
+#    in interactive bash), producing a `syntax error near unexpected token '('`.
+SQRBX_INIT="${USER_HOME}/.squarebox-shell-init"
+cat > "$SQRBX_INIT" <<'SQRBXEOF'
+# Managed by squarebox install.sh — overwritten on every install.
+# Drop any stale aliases with these names so they don't shadow the functions.
+unalias sqrbx squarebox sqrbx-rebuild squarebox-rebuild 2>/dev/null || true
+sqrbx() { if command -v winpty &>/dev/null && [[ -n "${MSYSTEM:-}" ]]; then winpty docker start -ai squarebox; else docker start -ai squarebox; fi; }
+squarebox() { sqrbx "$@"; }
+sqrbx-rebuild() { "$HOME/squarebox/install.sh" "$@"; }
+squarebox-rebuild() { sqrbx-rebuild "$@"; }
+SQRBXEOF
+
+# Scrub legacy content from $SHELL_RC and append a fresh sentinel block that
+# sources $SQRBX_INIT. Portable awk + mktemp + mv (no `sed -i` GNU/BSD footgun).
+if [ -f "$SHELL_RC" ]; then
+	_rc_tmp="$(mktemp "${SHELL_RC}.sqrbx.XXXXXX")"
+	awk '
+		/^# >>> squarebox >>>/ { skip=1; next }
+		/^# <<< squarebox <<</ { skip=0; next }
+		skip { next }
+		/^[[:space:]]*alias[[:space:]]+(sqrbx|squarebox|sqrbx-rebuild|squarebox-rebuild)=/ { next }
+		/^(sqrbx|squarebox|sqrbx-rebuild|squarebox-rebuild)\(\)[[:space:]]*\{/ { next }
+		{ print }
+	' "$SHELL_RC" > "$_rc_tmp" && mv "$_rc_tmp" "$SHELL_RC"
+	_rc_tmp=""
+fi
+
+cat >> "$SHELL_RC" <<'SQRBXRCEOF'
+# >>> squarebox >>>
+[ -f "$HOME/.squarebox-shell-init" ] && . "$HOME/.squarebox-shell-init"
+# <<< squarebox <<<
+SQRBXRCEOF
+
+echo "Installed squarebox shell integration → $SHELL_RC"
+
+# Self-check: catch future regressions that would break the rc file at source time.
+if ! bash -n "$SHELL_RC" 2>/dev/null; then
+	echo "Warning: $SHELL_RC fails bash syntax check after edit — please inspect." >&2
+fi
+# end squarebox shell integration
 
 # Git Bash on Windows opens a login shell which reads .bash_profile (not
 # .bashrc). Ensure .bash_profile sources .bashrc so aliases are available.
@@ -168,46 +201,93 @@ _pwsh=""
 if command -v pwsh &>/dev/null; then
 	_pwsh="$(command -v pwsh)"
 elif [ -n "${MSYSTEM:-}" ] || [ -n "${USERPROFILE:-}" ]; then
-	# pwsh is often not on Git Bash's PATH — search common Windows install locations
-	for _candidate in \
-		"$(cygpath -u "${PROGRAMFILES:-/c/Program Files}" 2>/dev/null)/PowerShell/7/pwsh.exe" \
-		"$(cygpath -u "${LOCALAPPDATA:-}" 2>/dev/null)/Microsoft/PowerShell/pwsh.exe"; do
-		if [ -x "$_candidate" ] 2>/dev/null; then
-			_pwsh="$_candidate"
-			break
+	# pwsh is typically not on Git Bash's PATH. Try where.exe first (queries the
+	# Windows PATH that Git Bash doesn't fully inherit), then fall back to
+	# probing common install locations directly.
+	if command -v where.exe &>/dev/null; then
+		_where_pwsh="$(where.exe pwsh 2>/dev/null | tr -d '\r' | head -1 || true)"
+		if [ -n "$_where_pwsh" ]; then
+			_pwsh="$(cygpath -u "$_where_pwsh" 2>/dev/null || echo "$_where_pwsh")"
 		fi
-	done
+	fi
+	if [ -z "$_pwsh" ]; then
+		for _candidate in \
+			"$(cygpath -u "${PROGRAMFILES:-/c/Program Files}" 2>/dev/null)/PowerShell/7/pwsh.exe" \
+			"$(cygpath -u "${LOCALAPPDATA:-}" 2>/dev/null)/Microsoft/PowerShell/7/pwsh.exe" \
+			"$(cygpath -u "${LOCALAPPDATA:-}" 2>/dev/null)/Microsoft/WindowsApps/pwsh.exe"; do
+			if [ -x "$_candidate" ] 2>/dev/null; then
+				_pwsh="$_candidate"
+				break
+			fi
+		done
+	fi
 fi
 
 if [ -n "$_pwsh" ]; then
 	[ "$VERBOSE" = 1 ] && echo "PowerShell: using $_pwsh"
-	_ps_profile_raw="$("$_pwsh" -NoProfile -Command '$PROFILE' 2>/dev/null | tr -d '\r' || true)"
+	# -OutputFormat Text and [Console]::Out.Write avoid a trailing newline; strip
+	# any leftover CR plus a possible UTF-8 BOM that PowerShell sometimes emits.
+	_ps_profile_raw="$("$_pwsh" -NoProfile -NonInteractive \
+		-Command '[Console]::Out.Write($PROFILE)' 2>/dev/null \
+		| tr -d '\r' \
+		| sed $'1s/^\xEF\xBB\xBF//' || true)"
 	[ "$VERBOSE" = 1 ] && echo "PowerShell \$PROFILE: ${_ps_profile_raw:-<empty>}"
 	if [ -n "$_ps_profile_raw" ]; then
 		_ps_profile="$(cygpath -u "$_ps_profile_raw" 2>/dev/null || echo "$_ps_profile_raw")"
 		[ "$VERBOSE" = 1 ] && echo "PowerShell profile (unix): $_ps_profile"
+		# Sanity check: a real profile path lives under Documents/PowerShell or
+		# Documents/WindowsPowerShell. Guards against stray bytes producing bogus paths.
+		case "$_ps_profile" in
+			*/Documents/PowerShell/*|*/Documents/WindowsPowerShell/*|*/PowerShell/*) ;;
+			*)
+				echo "Warning: pwsh returned unexpected profile path ($_ps_profile) — skipping PowerShell profile setup." >&2
+				_ps_profile=""
+				;;
+		esac
+	fi
+	if [ -n "${_ps_profile:-}" ]; then
 		mkdir -p "$(dirname "$_ps_profile")"
-		if ! grep -q 'function sqrbx ' "$_ps_profile" 2>/dev/null; then
-			cat >> "$_ps_profile" <<-'PSEOF'
+		touch "$_ps_profile"
+		# Managed block: strip any existing squarebox block (or legacy one-line
+		# function defs) and append a fresh one. Same sentinel as the bash rc.
+		_ps_tmp="$(mktemp "${_ps_profile}.sqrbx.XXXXXX")"
+		awk '
+			/^# >>> squarebox >>>/ { skip=1; next }
+			/^# <<< squarebox <<</ { skip=0; next }
+			skip { next }
+			/^[[:space:]]*function[[:space:]]+(sqrbx|squarebox|sqrbx-rebuild|squarebox-rebuild)[[:space:]]*(\{|$)/ { next }
+			{ print }
+		' "$_ps_profile" > "$_ps_tmp" && mv "$_ps_tmp" "$_ps_profile"
 
-			# squarebox aliases
-			function sqrbx { docker start -ai squarebox }
-			function squarebox { docker start -ai squarebox }
-			function sqrbx-rebuild { bash "$HOME/squarebox/install.sh" }
-			function squarebox-rebuild { bash "$HOME/squarebox/install.sh" }
-			PSEOF
-			if grep -q 'function sqrbx ' "$_ps_profile" 2>/dev/null; then
-				echo "Added squarebox functions to PowerShell profile."
-			else
-				echo "Warning: failed to write squarebox functions to PowerShell profile." >&2
-				[ "$VERBOSE" = 1 ] && echo "  Tried to write to: $_ps_profile" >&2
-			fi
-		fi
-	else
-		echo "Warning: pwsh found but \$PROFILE returned empty — skipping PowerShell profile setup."
+		cat >> "$_ps_profile" <<'PSEOF'
+# >>> squarebox >>>
+# squarebox shell integration — managed by install.sh.
+Remove-Item Alias:sqrbx, Alias:squarebox, Alias:sqrbx-rebuild, Alias:squarebox-rebuild -ErrorAction SilentlyContinue
+function sqrbx { docker start -ai squarebox }
+function squarebox { docker start -ai squarebox }
+function sqrbx-rebuild {
+    $bash = @(
+        "$env:PROGRAMFILES\Git\bin\bash.exe",
+        "${env:PROGRAMFILES(x86)}\Git\bin\bash.exe",
+        (Get-Command bash.exe -ErrorAction SilentlyContinue).Source
+    ) | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
+    if (-not $bash) {
+        Write-Error "squarebox: Git Bash not found — install Git for Windows."
+        return
+    }
+    & $bash "$env:USERPROFILE/squarebox/install.sh" @args
+}
+function squarebox-rebuild { sqrbx-rebuild @args }
+# <<< squarebox <<<
+PSEOF
+		echo "Installed squarebox shell integration → $_ps_profile"
+	elif [ -z "$_ps_profile_raw" ]; then
+		echo "Warning: pwsh found but \$PROFILE returned empty — skipping PowerShell profile setup." >&2
 	fi
 elif [ -n "${MSYSTEM:-}" ] || [ -n "${USERPROFILE:-}" ]; then
-	[ "$VERBOSE" = 1 ] && echo "PowerShell: pwsh not found on PATH or in standard locations — skipping."
+	# Always notify on Windows — a silent skip was the main reason the last
+	# round of "aliases not being added" bugs was hard to diagnose.
+	echo "Note: pwsh not found on PATH or in standard install locations — skipping PowerShell profile setup."
 fi
 
 # Prepare host directories

--- a/install.sh
+++ b/install.sh
@@ -139,15 +139,23 @@ fi
 #    versions gets scrubbed on every run — critical because an old alias
 #    shadows the new function definition at parse time (expand_aliases is on
 #    in interactive bash), producing a `syntax error near unexpected token '('`.
-SQRBX_INIT="${USER_HOME}/.squarebox-shell-init"
-cat > "$SQRBX_INIT" <<'SQRBXEOF'
+#
+# The init file lives under $HOME (not $USER_HOME): on Git Bash these diverge
+# (HOME=/home/user, USER_HOME=C:/Users/... from USERPROFILE), and the sentinel
+# in $SHELL_RC sources `$HOME/.squarebox-shell-init` at shell startup — the
+# init file must live where the running shell looks for it. The install dir
+# itself still lives under USER_HOME, so INSTALL_DIR is baked into the body
+# of sqrbx-rebuild below (unquoted heredoc) rather than using a runtime
+# `$HOME/squarebox/install.sh` which would be wrong on Git Bash.
+SQRBX_INIT="${HOME}/.squarebox-shell-init"
+cat > "$SQRBX_INIT" <<SQRBXEOF
 # Managed by squarebox install.sh — overwritten on every install.
 # Drop any stale aliases with these names so they don't shadow the functions.
 unalias sqrbx squarebox sqrbx-rebuild squarebox-rebuild 2>/dev/null || true
-sqrbx() { if command -v winpty &>/dev/null && [[ -n "${MSYSTEM:-}" ]]; then winpty docker start -ai squarebox; else docker start -ai squarebox; fi; }
-squarebox() { sqrbx "$@"; }
-sqrbx-rebuild() { "$HOME/squarebox/install.sh" "$@"; }
-squarebox-rebuild() { sqrbx-rebuild "$@"; }
+sqrbx() { if command -v winpty &>/dev/null && [[ -n "\${MSYSTEM:-}" ]]; then winpty docker start -ai squarebox; else docker start -ai squarebox; fi; }
+squarebox() { sqrbx "\$@"; }
+sqrbx-rebuild() { "${INSTALL_DIR}/install.sh" "\$@"; }
+squarebox-rebuild() { sqrbx-rebuild "\$@"; }
 SQRBXEOF
 
 # Scrub legacy content from $SHELL_RC and append a fresh sentinel block that
@@ -173,10 +181,21 @@ SQRBXRCEOF
 
 echo "Installed squarebox shell integration → $SHELL_RC"
 
-# Self-check: catch future regressions that would break the rc file at source time.
-if ! bash -n "$SHELL_RC" 2>/dev/null; then
-	echo "Warning: $SHELL_RC fails bash syntax check after edit — please inspect." >&2
-fi
+# Self-check: catch future regressions that would break the rc file at source
+# time. Use the matching shell's parser — bash -n rejects valid zsh syntax
+# (setopt, glob qualifiers, etc.) and would trigger false warnings for zsh users.
+case "$SHELL_RC" in
+	*.bashrc|*.bash_profile|*/.bashrc|*/.bash_profile)
+		if ! bash -n "$SHELL_RC" 2>/dev/null; then
+			echo "Warning: $SHELL_RC fails bash syntax check after edit — please inspect." >&2
+		fi
+		;;
+	*.zshrc|*.zprofile|*/.zshrc|*/.zprofile)
+		if command -v zsh >/dev/null 2>&1 && ! zsh -n "$SHELL_RC" 2>/dev/null; then
+			echo "Warning: $SHELL_RC fails zsh syntax check after edit — please inspect." >&2
+		fi
+		;;
+esac
 # end squarebox shell integration
 
 # Git Bash on Windows opens a login shell which reads .bash_profile (not
@@ -238,7 +257,7 @@ if [ -n "$_pwsh" ]; then
 		# Sanity check: a real profile path lives under Documents/PowerShell or
 		# Documents/WindowsPowerShell. Guards against stray bytes producing bogus paths.
 		case "$_ps_profile" in
-			*/Documents/PowerShell/*|*/Documents/WindowsPowerShell/*|*/PowerShell/*) ;;
+			*/Documents/PowerShell/*|*/Documents/WindowsPowerShell/*) ;;
 			*)
 				echo "Warning: pwsh returned unexpected profile path ($_ps_profile) — skipping PowerShell profile setup." >&2
 				_ps_profile=""


### PR DESCRIPTION
Two regressions from the past ~2 days caused shell integration to break:

Bug 1 — Linux: bash syntax error at source time
Commit 646a589 switched from writing `alias sqrbx='...'` to writing shell
functions (`sqrbx() { ... }`), but `_add_shell_func` only guarded against
re-adding functions. Legacy alias lines from pre-646a589 installs stayed
in .bashrc, and when bash sourced the file interactively (expand_aliases
on), alias expansion happened at parse time — turning `sqrbx()` into
`docker start -ai squarebox()` and producing:

  syntax error near unexpected token `('

Bug 2 — Windows: PowerShell profile never updated
- `$LOCALAPPDATA/Microsoft/PowerShell/pwsh.exe` was missing the `/7/`
  component, so the per-user install never got found.
- Microsoft Store install path was not checked.
- Commit 55f9183 gated every diagnostic behind --verbose, so a silent
  skip gave users zero feedback.
- The PS `sqrbx-rebuild` function invoked bare `bash`, which can resolve
  to WSL bash instead of Git Bash when launched from PowerShell.

Fix: managed block + dedicated sourced file

Mirror the Dockerfile pattern (~/.squarebox-*-aliases sourced from
~/.bashrc). install.sh now:

- Writes the four function bodies to ~/.squarebox-shell-init, overwritten
  unconditionally on every run (plus an inline `unalias` as belt-and-
  suspenders against any alias shadowing).
- Scrubs legacy content from $SHELL_RC via portable awk + mktemp + mv:
  removes any prior `# >>> squarebox >>>` block, legacy standalone
  `alias sqrbx=...` lines, and legacy one-liner function defs from the
  646a589-era writer.
- Appends a stable one-line sentinel block to $SHELL_RC that sources
  the init file.
- Runs `bash -n $SHELL_RC` after editing as a self-check so future
  regressions that break the rc file are caught at install time.
- Forces `$SHELL_RC=$HOME/.bashrc` when MSYSTEM is set so rebuilds
  launched from a parent PowerShell target the right file.

For PowerShell:
- Discovery order: command -v → where.exe pwsh → file probes covering
  Program Files/PowerShell/7, LOCALAPPDATA/Microsoft/PowerShell/7, and
  LOCALAPPDATA/Microsoft/WindowsApps.
- $PROFILE capture uses `[Console]::Out.Write` plus BOM + CR stripping
  to avoid trailing-newline and UTF-8 BOM contamination.
- Sanity-checks the returned profile path contains a Documents/PowerShell
  or Documents/WindowsPowerShell component before using it.
- Applies the same managed-block pattern (awk scrub + sentinel append)
  to the PS profile.
- PowerShell `sqrbx-rebuild` now explicitly resolves Git Bash at runtime
  (Program Files/Git/bin/bash.exe, with PATH fallback) so it never runs
  install.sh under WSL.
- Un-gates the "pwsh not found, skipping" message so Windows users
  always see feedback.

Also updates .github/workflows/e2e.yml 1.4 to exercise the real
managed-block logic from install.sh against a fixture containing the
exact legacy cruft that triggered Bug 1 — a permanent regression guard.