### PR TITLE
install: reclaim host ownership before writing git config

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -313,20 +313,25 @@ fi
 # Prepare host directories
 mkdir -p "${USER_HOME}/.config/git" "${INSTALL_DIR}/workspace" "${INSTALL_DIR}/.config/lazygit"
 
-# On Linux where host uid != 1000, a previous install may have chowned these
-# paths to 1000:1000 (for the container's `dev` user). On this run we need to
-# write to them as the host user first, so reclaim ownership before the writes.
-# The final chown-to-1000 still happens further down.
-if [ "$(uname -s)" = "Linux" ] && [ "$(id -u)" -ne 1000 ]; then
-	_reclaim_paths=(
-		"${USER_HOME}/.config/git"
-		"${INSTALL_DIR}/workspace"
-		"${INSTALL_DIR}/.config"
-	)
+# On Linux where host uid != 1000, a previous install may have chowned
+# ${USER_HOME}/.config/git to 1000:1000 (for the container's `dev` user), so
+# `git config --file` below would fail with "could not lock config file". If
+# that's the case, reclaim ownership back to the current user before writing.
+# Only this one path needs reclaiming — INSTALL_DIR/workspace is never written
+# to from install.sh, and INSTALL_DIR/.config writes further down are all
+# guarded by `[ ! -f ]` so only fire on first install where we just mkdir'd
+# the dir as the current user. The final chown-to-1000 still runs further down.
+if [ "$(uname -s)" = "Linux" ] && [ "$(id -u)" -ne 1000 ] && [ ! -w "${USER_HOME}/.config/git" ]; then
 	if [ "$(id -u)" -eq 0 ]; then
-		chown -R "$(id -u):$(id -g)" "${_reclaim_paths[@]}" 2>/dev/null || true
+		chown -R "$(id -u):$(id -g)" "${USER_HOME}/.config/git"
 	elif command -v sudo &>/dev/null; then
-		sudo chown -R "$(id -u):$(id -g)" "${_reclaim_paths[@]}" 2>/dev/null || true
+		sudo chown -R "$(id -u):$(id -g)" "${USER_HOME}/.config/git"
+	fi
+	if [ ! -w "${USER_HOME}/.config/git" ]; then
+		echo "Error: ${USER_HOME}/.config/git is not writable by uid $(id -u)." >&2
+		echo "       A previous install chowned it to uid 1000 for the container." >&2
+		echo "       Fix: sudo chown -R $(id -u):$(id -g) ${USER_HOME}/.config/git" >&2
+		exit 1
 	fi
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -93,7 +93,8 @@ fi
 # Build
 _build_log="$(mktemp)"
 _rc_tmp=""
-trap 'rm -f "$_build_log" "$_rc_tmp" 2>/dev/null || true' EXIT
+_create_log=""
+trap 'rm -f "$_build_log" "$_rc_tmp" "$_create_log" 2>/dev/null || true' EXIT
 if [ "$VERBOSE" = 1 ]; then
 	echo "Building image..."
 	docker_cmd build -t "$IMAGE_NAME" "$INSTALL_DIR"
@@ -312,6 +313,23 @@ fi
 # Prepare host directories
 mkdir -p "${USER_HOME}/.config/git" "${INSTALL_DIR}/workspace" "${INSTALL_DIR}/.config/lazygit"
 
+# On Linux where host uid != 1000, a previous install may have chowned these
+# paths to 1000:1000 (for the container's `dev` user). On this run we need to
+# write to them as the host user first, so reclaim ownership before the writes.
+# The final chown-to-1000 still happens further down.
+if [ "$(uname -s)" = "Linux" ] && [ "$(id -u)" -ne 1000 ]; then
+	_reclaim_paths=(
+		"${USER_HOME}/.config/git"
+		"${INSTALL_DIR}/workspace"
+		"${INSTALL_DIR}/.config"
+	)
+	if [ "$(id -u)" -eq 0 ]; then
+		chown -R "$(id -u):$(id -g)" "${_reclaim_paths[@]}" 2>/dev/null || true
+	elif command -v sudo &>/dev/null; then
+		sudo chown -R "$(id -u):$(id -g)" "${_reclaim_paths[@]}" 2>/dev/null || true
+	fi
+fi
+
 # Propagate host git identity into the container's config directory.
 # This avoids fragile file mounts on Windows/MSYS2 and prevents leaking
 # credential helpers or tokens from the host's full git config.
@@ -398,10 +416,15 @@ fi
 # Drop all Linux capabilities except those needed for scoped sudo
 DOCKER_OPTS+=(--cap-drop=ALL --cap-add=CHOWN --cap-add=DAC_OVERRIDE --cap-add=FOWNER --cap-add=SETUID --cap-add=SETGID --cap-add=KILL)
 
-docker_cmd create -it --name "$CONTAINER_NAME" \
+_create_log="$(mktemp)"
+if ! docker_cmd create -it --name "$CONTAINER_NAME" \
 	"${DOCKER_OPTS[@]}" \
 	"${DOCKER_VOLUMES[@]}" \
-	"$IMAGE_NAME" > /dev/null
+	"$IMAGE_NAME" > "$_create_log" 2>&1; then
+	echo "Error: failed to create container '$CONTAINER_NAME'." >&2
+	cat "$_create_log" >&2
+	exit 1
+fi
 
 if [ -t 0 ]; then
 	docker_interactive start -ai "$CONTAINER_NAME"


### PR DESCRIPTION
On Linux where host uid != 1000, the existing post-write chown hands
~/.config/git (and the INSTALL_DIR/.config tree) to 1000:1000 so the
container's `dev` user can write them. That leaves the host user unable
to write those paths on the *next* install, so `git config --file
~/.config/git/config ...` aborts with "could not lock config file:
Permission denied". Under `set -e` the whole script then exits before
reaching `docker create`, so `sqrbx` later reports "No such container".

Reclaim ownership back to the current user right after `mkdir -p`, so
the host-side writes that follow always succeed. The existing
post-write chown to 1000:1000 is unchanged — final state is identical.

Also surface docker-create failures explicitly instead of swallowing
stdout into /dev/null, so future regressions in that step aren't silent.