### PR TITLE
Add install.ps1 for reliable PowerShell profile setup on Windows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ docker start -ai squarebox
 
 The `install.sh` script automates initial setup (clone, build, create container, add `sqrbx` shell alias). A `.devcontainer/devcontainer.json` is also provided for VS Code Dev Containers / Codespaces.
 
-**Windows PowerShell**: Only PowerShell 7+ (`pwsh`) is supported. Windows PowerShell 5.1 is not supported.
+**Windows PowerShell**: Only PowerShell 7+ (`pwsh`) is supported. Windows PowerShell 5.1 is not supported. `install.ps1` is the recommended Windows entry point — it writes the PowerShell profile natively (using `$PROFILE` directly, no cross-shell detection) and delegates Docker setup to `install.sh` via Git Bash. Running `install.sh` directly from Git Bash still works but only sets up bash aliases; it prints instructions to run `install.ps1` for PowerShell.
 
 ## First-Run Setup
 
@@ -85,7 +85,7 @@ The Dockerfile uses `SHELL ["/bin/bash", "-c"]` because `tool-lib.sh` relies on 
 - **Git Bash**: install.sh uses `MSYS_NO_PATHCONV=1` to prevent MSYS2 path mangling in Docker volume mounts.
 - **Install directory**: uses `USERPROFILE` (not MSYS2 `HOME`) so the clone lands at `C:\Users\<user>\squarebox`.
 - **`$HOME` vs `$USER_HOME`** (install.sh): on Git Bash these diverge — `$HOME` is the MSYS home (`/home/user`, where bash actually reads `.bashrc` from), while `$USER_HOME` is derived from `USERPROFILE` (`C:/Users/user`, where the clone lives). Things anchored to the running shell (rc files, the `~/.squarebox-shell-init` file the sentinel sources) must use `$HOME`; things anchored to the filesystem install (`$INSTALL_DIR`, git config path, volume mounts) use `$USER_HOME`. Baking `$INSTALL_DIR` into shell function bodies at install time avoids runtime `$HOME` resolving wrong. On Linux/macOS the two are identical.
-- **Shell integration**: install.sh writes the four function bodies to `~/.squarebox-shell-init` and adds a single sentinel-marked `. ~/.squarebox-shell-init` line to `~/.bashrc` / `~/.zshrc` / PowerShell `$PROFILE`. The sentinel block (`# >>> squarebox >>>` / `# <<< squarebox <<<`) is scrubbed and rewritten on every run, along with any legacy `alias sqrbx=...` or one-liner `sqrbx() {...}` lines from pre-646a589 installs (those collide with the function definitions at parse time due to `expand_aliases` and produce a `syntax error near unexpected token '('`).
+- **Shell integration**: install.sh writes bash/zsh function bodies to `~/.squarebox-shell-init` and adds a single sentinel-marked `. ~/.squarebox-shell-init` line to `~/.bashrc` / `~/.zshrc`. PowerShell profile setup is handled by `install.ps1` (uses `$PROFILE` natively — no cross-shell detection). The sentinel block (`# >>> squarebox >>>` / `# <<< squarebox <<<`) is scrubbed and rewritten on every run, along with any legacy `alias sqrbx=...` or one-liner `sqrbx() {...}` lines from pre-646a589 installs.
 
 ## Tool Registry
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ If the install fails or you want to see the full docker build and git output, re
 
     curl -fsSL https://raw.githubusercontent.com/SquareWaveSystems/squarebox/main/install.sh | bash -s -- --verbose
 
+**Windows (PowerShell 7+)**
+
+Windows users can install directly from PowerShell, which also sets up
+PowerShell aliases (`sqrbx`, `squarebox`, etc.):
+
+    irm https://raw.githubusercontent.com/SquareWaveSystems/squarebox/main/install.ps1 | iex
+
+Or if you already have the repo cloned:
+
+    .\install.ps1
+
+This runs `install.sh` via Git Bash under the hood and then writes the
+PowerShell profile. Pass `-Edge` or `-Verbose` for the same options as above.
+
 Start
 -----
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,94 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Windows installer for squarebox. Writes PowerShell profile aliases
+    and delegates Docker/bash setup to install.sh via Git Bash.
+.DESCRIPTION
+    Run this from PowerShell 7+ to install squarebox with working PowerShell
+    aliases. Equivalent to running install.sh from Git Bash, but also sets up
+    your PowerShell profile so sqrbx/squarebox commands work in PowerShell.
+
+    First install:  irm https://raw.githubusercontent.com/SquareWaveSystems/squarebox/main/install.ps1 | iex
+    Re-install:     .\install.ps1
+    Edge:           .\install.ps1 -Edge
+#>
+#Requires -Version 7.0
+
+param(
+    [switch]$Edge,
+    [switch]$Verbose
+)
+
+$ErrorActionPreference = 'Stop'
+
+# --- Find Git Bash ---
+$bashCandidates = @(
+    "$env:PROGRAMFILES\Git\bin\bash.exe"
+    "${env:PROGRAMFILES(x86)}\Git\bin\bash.exe"
+)
+$gcm = Get-Command bash.exe -ErrorAction SilentlyContinue
+if ($gcm) { $bashCandidates += $gcm.Source }
+
+$bash = $bashCandidates | Where-Object { $_ -and (Test-Path $_) } |
+    Select-Object -First 1
+if (-not $bash) {
+    Write-Error "Git Bash not found. Install Git for Windows: https://git-scm.com/download/win"
+    exit 1
+}
+
+# --- Run install.sh (clone, build, container, bash profile) ---
+$installArgs = @('--no-pwsh')
+if ($Edge)    { $installArgs += '--edge' }
+if ($Verbose) { $installArgs += '--verbose' }
+
+$InstallDir = Join-Path $env:USERPROFILE 'squarebox'
+$installSh  = Join-Path $InstallDir 'install.sh'
+
+if (Test-Path $installSh) {
+    & $bash $installSh @installArgs
+} else {
+    # First install: pipe install.sh from GitHub (it clones the repo)
+    $url = 'https://raw.githubusercontent.com/SquareWaveSystems/squarebox/main/install.sh'
+    $script = (Invoke-WebRequest -Uri $url -UseBasicParsing).Content
+    $script | & $bash -s -- @installArgs
+}
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "install.sh failed (exit code $LASTEXITCODE)"
+    exit $LASTEXITCODE
+}
+
+# --- PowerShell profile setup ---
+$profileDir = Split-Path $PROFILE
+if (-not (Test-Path $profileDir)) {
+    New-Item -ItemType Directory -Path $profileDir -Force | Out-Null
+}
+
+# Strip existing managed block and legacy function defs
+if (Test-Path $PROFILE) {
+    $lines = Get-Content $PROFILE
+    $filtered = [System.Collections.Generic.List[string]]::new()
+    $skip = $false
+    foreach ($line in $lines) {
+        if ($line -match '^# >>> squarebox >>>') { $skip = $true; continue }
+        if ($line -match '^# <<< squarebox <<<') { $skip = $false; continue }
+        if ($skip) { continue }
+        if ($line -match '^\s*function\s+(sqrbx|squarebox|sqrbx-rebuild|squarebox-rebuild)\s') { continue }
+        $filtered.Add($line)
+    }
+    Set-Content -Path $PROFILE -Value ($filtered -join "`n")
+}
+
+# Append managed block
+@'
+
+# >>> squarebox >>>
+# squarebox shell integration — managed by install.ps1.
+Remove-Item Alias:sqrbx, Alias:squarebox, Alias:sqrbx-rebuild, Alias:squarebox-rebuild -ErrorAction SilentlyContinue
+function sqrbx { docker start -ai squarebox }
+function squarebox { docker start -ai squarebox }
+function sqrbx-rebuild { & "$env:USERPROFILE\squarebox\install.ps1" @args }
+function squarebox-rebuild { sqrbx-rebuild @args }
+# <<< squarebox <<<
+'@ | Add-Content -Path $PROFILE
+
+Write-Host "Installed squarebox shell integration -> $PROFILE"

--- a/install.ps1
+++ b/install.ps1
@@ -47,10 +47,18 @@ $installSh  = Join-Path $InstallDir 'install.sh'
 if (Test-Path $installSh) {
     & $bash $installSh @installArgs
 } else {
-    # First install: pipe install.sh from GitHub (it clones the repo)
+    # First install: download install.sh to a temp file and execute it.
+    # Piping a string through PowerShell to bash can introduce CRLF / encoding
+    # changes that break bash parsing. Using a temp file keeps the script
+    # byte-identical to what the server sent.
     $url = 'https://raw.githubusercontent.com/SquareWaveSystems/squarebox/main/install.sh'
-    $script = (Invoke-WebRequest -Uri $url -UseBasicParsing).Content
-    $script | & $bash -s -- @installArgs
+    $tmp = Join-Path ([System.IO.Path]::GetTempPath()) 'squarebox-install.sh'
+    try {
+        Invoke-WebRequest -Uri $url -UseBasicParsing -OutFile $tmp
+        & $bash $tmp @installArgs
+    } finally {
+        Remove-Item $tmp -ErrorAction SilentlyContinue
+    }
 }
 if ($LASTEXITCODE -ne 0) {
     Write-Error "install.sh failed (exit code $LASTEXITCODE)"
@@ -72,7 +80,7 @@ if (Test-Path $PROFILE) {
         if ($line -match '^# >>> squarebox >>>') { $skip = $true; continue }
         if ($line -match '^# <<< squarebox <<<') { $skip = $false; continue }
         if ($skip) { continue }
-        if ($line -match '^\s*function\s+(sqrbx|squarebox|sqrbx-rebuild|squarebox-rebuild)\s') { continue }
+        if ($line -match '^\s*function\s+(sqrbx|squarebox|sqrbx-rebuild|squarebox-rebuild)\s*(\{|$)') { continue }
         $filtered.Add($line)
     }
     Set-Content -Path $PROFILE -Value ($filtered -join "`n")
@@ -80,7 +88,6 @@ if (Test-Path $PROFILE) {
 
 # Append managed block
 @'
-
 # >>> squarebox >>>
 # squarebox shell integration — managed by install.ps1.
 Remove-Item Alias:sqrbx, Alias:squarebox, Alias:sqrbx-rebuild, Alias:squarebox-rebuild -ErrorAction SilentlyContinue

--- a/install.sh
+++ b/install.sh
@@ -40,11 +40,13 @@ IMAGE_NAME="squarebox"
 CONTAINER_NAME="squarebox"
 EDGE="${SQUAREBOX_EDGE:-0}"
 VERBOSE=0
+NO_PWSH=0
 
 for arg in "$@"; do
 	case "$arg" in
 		--edge) EDGE=1 ;;
 		--verbose) VERBOSE=1 ;;
+		--no-pwsh) NO_PWSH=1 ;;
 	esac
 done
 
@@ -214,100 +216,15 @@ if [[ -n "${MSYSTEM:-}" ]] && [[ "${SHELL_RC}" == *".bashrc" ]]; then
 	fi
 fi
 
-# PowerShell 7+ profile (Windows) — uses functions since PS aliases can't take arguments.
-# Only pwsh (7+) is supported; Windows PowerShell 5.1 is not.
-# Query pwsh for the actual $PROFILE path since Documents may be redirected (e.g. OneDrive).
-_pwsh=""
-if command -v pwsh &>/dev/null; then
-	_pwsh="$(command -v pwsh)"
-elif [ -n "${MSYSTEM:-}" ] || [ -n "${USERPROFILE:-}" ]; then
-	# pwsh is typically not on Git Bash's PATH. Try where.exe first (queries the
-	# Windows PATH that Git Bash doesn't fully inherit), then fall back to
-	# probing common install locations directly.
-	if command -v where.exe &>/dev/null; then
-		_where_pwsh="$(where.exe pwsh 2>/dev/null | tr -d '\r' | head -1 || true)"
-		if [ -n "$_where_pwsh" ]; then
-			_pwsh="$(cygpath -u "$_where_pwsh" 2>/dev/null || echo "$_where_pwsh")"
-		fi
-	fi
-	if [ -z "$_pwsh" ]; then
-		for _candidate in \
-			"$(cygpath -u "${PROGRAMFILES:-/c/Program Files}" 2>/dev/null)/PowerShell/7/pwsh.exe" \
-			"$(cygpath -u "${LOCALAPPDATA:-}" 2>/dev/null)/Microsoft/PowerShell/7/pwsh.exe" \
-			"$(cygpath -u "${LOCALAPPDATA:-}" 2>/dev/null)/Microsoft/WindowsApps/pwsh.exe"; do
-			if [ -x "$_candidate" ] 2>/dev/null; then
-				_pwsh="$_candidate"
-				break
-			fi
-		done
-	fi
-fi
-
-if [ -n "$_pwsh" ]; then
-	[ "$VERBOSE" = 1 ] && echo "PowerShell: using $_pwsh"
-	# -OutputFormat Text and [Console]::Out.Write avoid a trailing newline; strip
-	# any leftover CR plus a possible UTF-8 BOM that PowerShell sometimes emits.
-	_ps_profile_raw="$("$_pwsh" -NoProfile -NonInteractive \
-		-Command '[Console]::Out.Write($PROFILE)' 2>/dev/null \
-		| tr -d '\r' \
-		| sed $'1s/^\xEF\xBB\xBF//' || true)"
-	[ "$VERBOSE" = 1 ] && echo "PowerShell \$PROFILE: ${_ps_profile_raw:-<empty>}"
-	if [ -n "$_ps_profile_raw" ]; then
-		_ps_profile="$(cygpath -u "$_ps_profile_raw" 2>/dev/null || echo "$_ps_profile_raw")"
-		[ "$VERBOSE" = 1 ] && echo "PowerShell profile (unix): $_ps_profile"
-		# Sanity check: a real profile path lives under Documents/PowerShell or
-		# Documents/WindowsPowerShell. Guards against stray bytes producing bogus paths.
-		case "$_ps_profile" in
-			*/Documents/PowerShell/*|*/Documents/WindowsPowerShell/*) ;;
-			*)
-				echo "Warning: pwsh returned unexpected profile path ($_ps_profile) — skipping PowerShell profile setup." >&2
-				_ps_profile=""
-				;;
-		esac
-	fi
-	if [ -n "${_ps_profile:-}" ]; then
-		mkdir -p "$(dirname "$_ps_profile")"
-		touch "$_ps_profile"
-		# Managed block: strip any existing squarebox block (or legacy one-line
-		# function defs) and append a fresh one. Same sentinel as the bash rc.
-		_ps_tmp="$(mktemp "${_ps_profile}.sqrbx.XXXXXX")"
-		awk '
-			/^# >>> squarebox >>>/ { skip=1; next }
-			/^# <<< squarebox <<</ { skip=0; next }
-			skip { next }
-			/^[[:space:]]*function[[:space:]]+(sqrbx|squarebox|sqrbx-rebuild|squarebox-rebuild)[[:space:]]*(\{|$)/ { next }
-			{ print }
-		' "$_ps_profile" > "$_ps_tmp" && mv "$_ps_tmp" "$_ps_profile"
-
-		cat >> "$_ps_profile" <<'PSEOF'
-# >>> squarebox >>>
-# squarebox shell integration — managed by install.sh.
-Remove-Item Alias:sqrbx, Alias:squarebox, Alias:sqrbx-rebuild, Alias:squarebox-rebuild -ErrorAction SilentlyContinue
-function sqrbx { docker start -ai squarebox }
-function squarebox { docker start -ai squarebox }
-function sqrbx-rebuild {
-    $bash = @(
-        "$env:PROGRAMFILES\Git\bin\bash.exe",
-        "${env:PROGRAMFILES(x86)}\Git\bin\bash.exe",
-        (Get-Command bash.exe -ErrorAction SilentlyContinue).Source
-    ) | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
-    if (-not $bash) {
-        Write-Error "squarebox: Git Bash not found — install Git for Windows."
-        return
-    }
-    & $bash "$env:USERPROFILE/squarebox/install.sh" @args
-}
-function squarebox-rebuild { sqrbx-rebuild @args }
-# <<< squarebox <<<
-PSEOF
-		echo "Installed squarebox shell integration → $_ps_profile"
-	elif [ -z "$_ps_profile_raw" ]; then
-		echo "Warning: pwsh found but \$PROFILE returned empty — skipping PowerShell profile setup." >&2
-	fi
-elif [ -n "${MSYSTEM:-}" ] || [ -n "${USERPROFILE:-}" ]; then
-	# Always notify on Windows — a silent skip was the main reason the last
-	# round of "aliases not being added" bugs was hard to diagnose.
-	echo "Note: pwsh not found on PATH or in standard install locations — skipping PowerShell profile setup."
+# PowerShell 7+ profile (Windows). install.ps1 handles this natively — it
+# writes the profile using $PROFILE directly (no cross-shell detection needed).
+# When invoked with --no-pwsh (by install.ps1), skip this entirely.
+if [ "$NO_PWSH" != 1 ] && { [ -n "${MSYSTEM:-}" ] || [ -n "${USERPROFILE:-}" ]; }; then
+	_ps1_path="$(cygpath -w "${INSTALL_DIR}/install.ps1" 2>/dev/null || echo "${INSTALL_DIR}\\install.ps1")"
+	echo ""
+	echo "PowerShell: to add squarebox aliases to your PowerShell profile, run:"
+	echo "  pwsh -File \"${_ps1_path}\""
+	echo ""
 fi
 
 # Prepare host directories


### PR DESCRIPTION
The PowerShell alias bug has been "fixed" 5+ times (#42, #44, #45, #53,
#54, #55) because install.sh tried to detect pwsh from Git Bash — a
fundamentally fragile approach (MSYS2 PATH isolation, Store reparse
points, CRLF/BOM contamination, etc.).

New approach: let PowerShell handle its own profile natively.
install.ps1 writes the profile using $PROFILE directly (trivially
reliable), then delegates Docker/bash setup to install.sh --no-pwsh.
install.sh no longer attempts cross-shell detection — it just prints
instructions pointing to install.ps1.

Net: 96 lines of brittle detection code removed from install.sh,
replaced by a clean 95-line install.ps1 and a 7-line pointer message.

https://claude.ai/code/session_01PaJQ2YfgmEg4ZXiCsav24B