### PR TITLE
Change setup completion message to avoid duplicating "You're in the box."

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1168,7 +1168,7 @@ done
 echo
 
 if $HAS_GUM; then
-	gum style --border double --padding "0 2" --border-foreground 208 "🟧📦 squarebox setup complete."
+	gum style --border double --padding "0 2" --border-foreground 208 "🟧📦 All boxed up."
 else
-	echo "🟧📦 squarebox setup complete."
+	echo "🟧📦 All boxed up."
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -1168,7 +1168,7 @@ done
 echo
 
 if $HAS_GUM; then
-	gum style --border double --padding "0 2" --border-foreground 208 "🟧📦 You're in the box."
+	gum style --border double --padding "0 2" --border-foreground 208 "🟧📦 squarebox setup complete."
 else
-	echo "🟧📦 You're in the box."
+	echo "🟧📦 squarebox setup complete."
 fi


### PR DESCRIPTION
The bashrc/motd already displays "You're in the box." on shell start, so
the setup script now says "squarebox setup complete." instead.

https://claude.ai/code/session_01HqsgxcGc43uq79EWAYJ3yd