### PR TITLE
fix: use cygpath mixed-mode for Docker-compatible paths on Windows

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -30,8 +30,10 @@ docker_interactive() {
 # On MSYS2/Git Bash, HOME points to the MSYS home (/home/user) which maps to
 # an obscure Windows path (e.g. C:\Program Files\Git\home\user). Use USERPROFILE
 # instead so the install lands at a normal location (C:\Users\user\squarebox).
+# Mixed-mode (C:/Users/...) keeps paths compatible with both bash and Docker —
+# MSYS2-format (/c/Users/...) breaks Docker when MSYS_NO_PATHCONV=1 is set.
 if [ -n "${USERPROFILE:-}" ]; then
-	USER_HOME="$(cygpath -u "$USERPROFILE" 2>/dev/null || echo "$USERPROFILE")"
+	USER_HOME="$(cygpath -m "$USERPROFILE" 2>/dev/null || echo "$USERPROFILE")"
 else
 	USER_HOME="${HOME}"
 fi
@@ -265,7 +267,7 @@ _host_name="$(git config --global user.name 2>/dev/null || true)"
 _host_email="$(git config --global user.email 2>/dev/null || true)"
 
 if [ -z "$_host_name" ] && [ -n "${USERPROFILE:-}" ]; then
-	_win_gitcfg="$(cygpath -u "$USERPROFILE" 2>/dev/null || echo "$USERPROFILE")/.gitconfig"
+	_win_gitcfg="$(cygpath -m "$USERPROFILE" 2>/dev/null || echo "$USERPROFILE")/.gitconfig"
 	if [ -f "$_win_gitcfg" ]; then
 		_host_name="$(git config --file "$_win_gitcfg" user.name 2>/dev/null || true)"
 		_host_email="$(git config --file "$_win_gitcfg" user.email 2>/dev/null || true)"


### PR DESCRIPTION
cygpath -u produces MSYS2-format paths (/c/Users/...) which Docker for
Windows cannot resolve when MSYS_NO_PATHCONV=1 suppresses automatic
conversion. Switch to cygpath -m (C:/Users/...) which both bash and
Docker understand natively.

Fixes Docker build "unable to prepare context" error when running
install.ps1 on Windows.

https://claude.ai/code/session_01H6jMr6Hf7tqNCroQtwX7rV