### PR TITLE
fix: handle missing cygpath when Git Bash invoked from PowerShell

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,18 @@ PowerShell aliases (`sqrbx`, `squarebox`, etc.):
 
     irm https://raw.githubusercontent.com/SquareWaveSystems/squarebox/main/install.ps1 | iex
 
-Or if you already have the repo cloned:
+Once installed, you can re-run or pass flags from the local copy:
 
-    .\install.ps1
+    .\install.ps1              # re-install / update
+    .\install.ps1 -Edge        # latest main instead of latest release
+    .\install.ps1 -Verbose     # show full build output
+
+> **Note:** `irm ... | iex` does not support flags — PowerShell interprets them
+> as arguments to `Invoke-Expression`, not the script. Use the local
+> `.\install.ps1` form for `-Edge` or `-Verbose`.
 
 This runs `install.sh` via Git Bash under the hood and then writes the
-PowerShell profile. Pass `-Edge` or `-Verbose` for the same options as above.
+PowerShell profile.
 
 Start
 -----

--- a/install.ps1
+++ b/install.ps1
@@ -37,6 +37,9 @@ if (-not $bash) {
 }
 
 # --- Run install.sh (clone, build, container, bash profile) ---
+# Use --login so Git Bash sources /etc/profile, which adds /usr/bin to PATH.
+# Without this, cygpath and other MSYS2 tools may not be available when bash
+# is invoked non-interactively from PowerShell.
 $installArgs = @('--no-pwsh')
 if ($Edge)    { $installArgs += '--edge' }
 if ($Verbose) { $installArgs += '--verbose' }
@@ -45,7 +48,7 @@ $InstallDir = Join-Path $env:USERPROFILE 'squarebox'
 $installSh  = Join-Path $InstallDir 'install.sh'
 
 if (Test-Path $installSh) {
-    & $bash $installSh @installArgs
+    & $bash --login $installSh @installArgs
 } else {
     # First install: download install.sh to a temp file and execute it.
     # Piping a string through PowerShell to bash can introduce CRLF / encoding
@@ -55,7 +58,7 @@ if (Test-Path $installSh) {
     $tmp = Join-Path ([System.IO.Path]::GetTempPath()) 'squarebox-install.sh'
     try {
         Invoke-WebRequest -Uri $url -UseBasicParsing -OutFile $tmp
-        & $bash $tmp @installArgs
+        & $bash --login $tmp @installArgs
     } finally {
         Remove-Item $tmp -ErrorAction SilentlyContinue
     }

--- a/install.sh
+++ b/install.sh
@@ -32,8 +32,20 @@ docker_interactive() {
 # instead so the install lands at a normal location (C:\Users\user\squarebox).
 # Mixed-mode (C:/Users/...) keeps paths compatible with both bash and Docker —
 # MSYS2-format (/c/Users/...) breaks Docker when MSYS_NO_PATHCONV=1 is set.
+#
+# When Git Bash is invoked non-interactively from PowerShell (& bash.exe script),
+# /etc/profile isn't sourced and cygpath may not be on PATH. The fallback converts
+# MSYS2 POSIX paths (/c/Users/...) and Windows backslash paths (C:\Users\...)
+# to mixed-mode manually.
 if [ -n "${USERPROFILE:-}" ]; then
-	USER_HOME="$(cygpath -m "$USERPROFILE" 2>/dev/null || echo "$USERPROFILE")"
+	USER_HOME="$(cygpath -m "$USERPROFILE" 2>/dev/null || true)"
+	if [ -z "$USER_HOME" ]; then
+		USER_HOME="${USERPROFILE//\\//}"
+		# /c/Users/... → C:/Users/...
+		if [[ "$USER_HOME" =~ ^/([a-zA-Z])(/.*)$ ]]; then
+			USER_HOME="${BASH_REMATCH[1]^}:${BASH_REMATCH[2]}"
+		fi
+	fi
 else
 	USER_HOME="${HOME}"
 fi
@@ -267,7 +279,7 @@ _host_name="$(git config --global user.name 2>/dev/null || true)"
 _host_email="$(git config --global user.email 2>/dev/null || true)"
 
 if [ -z "$_host_name" ] && [ -n "${USERPROFILE:-}" ]; then
-	_win_gitcfg="$(cygpath -m "$USERPROFILE" 2>/dev/null || echo "$USERPROFILE")/.gitconfig"
+	_win_gitcfg="${USER_HOME}/.gitconfig"
 	if [ -f "$_win_gitcfg" ]; then
 		_host_name="$(git config --file "$_win_gitcfg" user.name 2>/dev/null || true)"
 		_host_email="$(git config --file "$_win_gitcfg" user.email 2>/dev/null || true)"


### PR DESCRIPTION
When install.ps1 invokes Git Bash non-interactively (& bash.exe script),
/etc/profile isn't sourced and cygpath may not be on PATH. The fallback
`echo "$USERPROFILE"` passes the raw MSYS2 POSIX path (/c/Users/...)
which Docker can't resolve because MSYS_NO_PATHCONV=1 suppresses
automatic conversion.

Two-pronged fix:
- install.ps1: add --login so bash sources /etc/profile (primary fix)
- install.sh: add manual POSIX-to-mixed-mode fallback when cygpath is
  unavailable (/c/Users/... → C:/Users/...), as defense in depth

Also reuse the already-resolved USER_HOME for the git config fallback
path instead of calling cygpath a second time.

https://claude.ai/code/session_01GMPR7m8zbe6WTF7qQf6N8y