### PR TITLE
fix: use Bash-3-compatible uppercase for drive letter in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,7 +43,7 @@ if [ -n "${USERPROFILE:-}" ]; then
 		USER_HOME="${USERPROFILE//\\//}"
 		# /c/Users/... → C:/Users/...
 		if [[ "$USER_HOME" =~ ^/([a-zA-Z])(/.*)$ ]]; then
-			USER_HOME="${BASH_REMATCH[1]^}:${BASH_REMATCH[2]}"
+			USER_HOME="$(printf '%s' "${BASH_REMATCH[1]}" | tr '[:lower:]' '[:upper:]'):${BASH_REMATCH[2]}"
 		fi
 	fi
 else


### PR DESCRIPTION
The ${var^} expansion requires Bash 4+, but macOS ships Bash 3.2.
Replace with printf | tr to avoid "bad substitution" errors when the
installer is piped to bash on macOS.

https://claude.ai/code/session_01ULCPhcKnub3FGvjbcZ1koK