### PR TITLE
fix: source alias files after first-run setup; clean up setup emojis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -156,6 +156,9 @@ if [ ! -f ~/.squarebox-setup-done ]; then
 		touch ~/.squarebox-setup-done
 	else
 		~/setup.sh && touch ~/.squarebox-setup-done
+		[ -f ~/.squarebox-ai-aliases ] && source ~/.squarebox-ai-aliases
+		[ -f ~/.squarebox-editor-aliases ] && source ~/.squarebox-editor-aliases
+		[ -f ~/.squarebox-tui-aliases ] && source ~/.squarebox-tui-aliases
 		[ -f ~/.squarebox-sdk-paths ] && source ~/.squarebox-sdk-paths
 	fi
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -63,9 +63,9 @@ run_with_spinner() {
 }
 
 if $HAS_GUM; then
-	gum style --border double --padding "0 2" --border-foreground 208 "squarebox setup"
+	gum style --border double --padding "0 2" --border-foreground 208 "📦 squarebox setup"
 else
-	echo "=== squarebox setup ==="
+	echo "=== 📦 squarebox setup ==="
 fi
 echo
 
@@ -1168,7 +1168,7 @@ done
 echo
 
 if $HAS_GUM; then
-	gum style --border double --padding "0 2" --border-foreground 208 "🟧📦 All boxed up."
+	gum style --border double --padding "0 2" --border-foreground 208 "All boxed up 📦"
 else
-	echo "🟧📦 All boxed up."
+	echo "All boxed up 📦"
 fi


### PR DESCRIPTION
## Summary

- **Re-source alias files after first-run setup** — On first container launch, `~/.squarebox-ai-aliases` (which defines the `c` alias) was created by `setup.sh` but never re-sourced into the current shell. The initial source in `.bashrc` runs before `setup.sh`, when the file doesn't exist yet. Only `~/.squarebox-sdk-paths` was re-sourced after setup. Now all alias files are re-sourced to match.

- **Clean up setup header/footer emojis** — Add `📦` to the "squarebox setup" header box. Change completion message from `🟧📦 All boxed up.` to `All boxed up 📦` — the `🟧` (Unicode 12.0) renders as `◆` on many terminals, while `📦` (Unicode 6.0) has broad support.

## Test plan

- [ ] Build container and verify first-run `c` alias works without restarting the shell
- [ ] Verify "📦 squarebox setup" header displays correctly
- [ ] Verify "All boxed up 📦" completion message displays correctly
- [ ] Verify aliases still work on subsequent container starts

https://claude.ai/code/session_01Edh56FubqjigsTh15BoiLw