### PR TITLE
fix: add orange square emoji next to box emoji in setup header

### DIFF
--- a/demo/setup-demo.sh
+++ b/demo/setup-demo.sh
@@ -22,7 +22,7 @@ sleep 0.5
 
 # --- Header ---
 echo
-gum style --border double --padding "0 2" --border-foreground 208 "squarebox setup"
+gum style --border double --padding "0 2" --border-foreground 208 "🟧📦 squarebox setup"
 echo
 
 # GitHub CLI (already authenticated)

--- a/setup.sh
+++ b/setup.sh
@@ -63,9 +63,9 @@ run_with_spinner() {
 }
 
 if $HAS_GUM; then
-	gum style --border double --padding "0 2" --border-foreground 208 "📦 squarebox setup"
+	gum style --border double --padding "0 2" --border-foreground 208 "🟧📦 squarebox setup"
 else
-	echo "=== 📦 squarebox setup ==="
+	echo "=== 🟧📦 squarebox setup ==="
 fi
 echo
 


### PR DESCRIPTION
The setup screen was missing the 🟧 emoji next to the 📦 emoji.
Added it to both setup.sh and the demo script.

https://claude.ai/code/session_01LNKFLzDj7yQ3sCFAR2DeFk