### PR TITLE
fix: use ANSI-C quoting for color sequences in sqrbx-update

### DIFF
--- a/scripts/squarebox-update.sh
+++ b/scripts/squarebox-update.sh
@@ -11,13 +11,13 @@ set -euo pipefail
 #   sqrbx-update --help       Show this help
 
 # Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-BOLD='\033[1m'
-DIM='\033[2m'
-RESET='\033[0m'
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+YELLOW=$'\033[1;33m'
+CYAN=$'\033[0;36m'
+BOLD=$'\033[1m'
+DIM=$'\033[2m'
+RESET=$'\033[0m'
 
 # ── Source shared tool library ─────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Use `$'\033[...]'` (ANSI-C quoting) instead of `'\033[...]'` for color definitions in `sqrbx-update`
- Bash does not interpret escape sequences inside single quotes, causing raw codes to be printed instead of colors

Fixes #52

## Test plan
- [ ] Run `sqrbx-update` inside the container and verify color output renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)