### PR TITLE
feat: rewrite install.ps1 as standalone PowerShell installer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ docker start -ai squarebox
 
 The `install.sh` script automates initial setup (clone, build, create container, add `sqrbx` shell alias). A `.devcontainer/devcontainer.json` is also provided for VS Code Dev Containers / Codespaces.
 
-**Windows PowerShell**: Only PowerShell 7+ (`pwsh`) is supported. Windows PowerShell 5.1 is not supported. `install.ps1` is the recommended Windows entry point — it writes the PowerShell profile natively (using `$PROFILE` directly, no cross-shell detection) and delegates Docker setup to `install.sh` via Git Bash. Running `install.sh` directly from Git Bash still works but only sets up bash aliases; it prints instructions to run `install.ps1` for PowerShell.
+**Windows PowerShell**: Only PowerShell 7+ (`pwsh`) is supported. Windows PowerShell 5.1 is not supported. `install.ps1` is the recommended Windows entry point — it handles clone, build, container creation, and PowerShell profile setup natively without requiring Git Bash. Running `install.sh` directly from Git Bash still works but only sets up bash aliases; it prints instructions to run `install.ps1` for PowerShell.
 
 ## First-Run Setup
 
@@ -84,10 +84,9 @@ The Dockerfile uses `SHELL ["/bin/bash", "-c"]` because `tool-lib.sh` relies on 
 ## Windows Support
 
 - **PowerShell**: only PowerShell 7+ (`pwsh`) is supported. Windows PowerShell 5.1 (`powershell.exe`) is not supported.
-- **Git Bash**: install.sh uses `MSYS_NO_PATHCONV=1` to prevent MSYS2 path mangling in Docker volume mounts.
-- **Install directory**: uses `USERPROFILE` (not MSYS2 `HOME`) so the clone lands at `C:\Users\<user>\squarebox`.
-- **`$HOME` vs `$USER_HOME`** (install.sh): on Git Bash these diverge — `$HOME` is the MSYS home (`/home/user`, where bash actually reads `.bashrc` from), while `$USER_HOME` is derived from `USERPROFILE` (`C:/Users/user`, where the clone lives). Things anchored to the running shell (rc files, the `~/.squarebox-shell-init` file the sentinel sources) must use `$HOME`; things anchored to the filesystem install (`$INSTALL_DIR`, git config path, volume mounts) use `$USER_HOME`. Baking `$INSTALL_DIR` into shell function bodies at install time avoids runtime `$HOME` resolving wrong. On Linux/macOS the two are identical.
-- **Shell integration**: install.sh writes bash/zsh function bodies to `~/.squarebox-shell-init` and adds a single sentinel-marked `. ~/.squarebox-shell-init` line to `~/.bashrc` / `~/.zshrc`. PowerShell profile setup is handled by `install.ps1` (uses `$PROFILE` natively — no cross-shell detection). The sentinel block (`# >>> squarebox >>>` / `# <<< squarebox <<<`) is scrubbed and rewritten on every run, along with any legacy `alias sqrbx=...` or one-liner `sqrbx() {...}` lines from pre-646a589 installs.
+- **install.ps1** (recommended for Windows): handles clone, build, container creation, and PowerShell profile setup natively — no Git Bash dependency. Uses `$env:USERPROFILE` for the install directory (`C:\Users\<user>\squarebox`) and `$PROFILE` for shell integration.
+- **install.sh via Git Bash** (alternative): still works but only sets up bash aliases. Uses `MSYS_NO_PATHCONV=1` to prevent MSYS2 path mangling in Docker volume mounts. On Git Bash, `$HOME` (MSYS home) and `$USER_HOME` (from `USERPROFILE`) diverge — see comments in install.sh for details.
+- **Shell integration**: install.ps1 writes a managed sentinel block (`# >>> squarebox >>>` / `# <<< squarebox <<<`) to the PowerShell `$PROFILE`. install.sh writes bash/zsh function bodies to `~/.squarebox-shell-init` and adds a sentinel-marked source line to `~/.bashrc` / `~/.zshrc`. Both scrub and rewrite their blocks on every run.
 
 ## Tool Registry
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,9 @@ testing, and submitting changes.
 
 ## Prerequisites
 
-- [Docker](https://docs.docker.com/get-docker/) (with buildx)
+- [Docker](https://docs.docker.com/get-docker/)
 - [Git](https://git-scm.com/)
-- Bash shell
+- Bash shell (or PowerShell 7+ on Windows)
 
 ## Build
 
@@ -48,7 +48,8 @@ docker run --rm squarebox:test bash -c '
 |------|---------|
 | `Dockerfile` | Image definition with pinned base-image tool versions |
 | `setup.sh` | First-run interactive setup (AI tools, editors, SDKs) |
-| `install.sh` | Host-side install script (clone, build, create container) |
+| `install.sh` | Host-side install script for Linux/macOS (clone, build, create container) |
+| `install.ps1` | Host-side install script for Windows/PowerShell 7+ |
 | `scripts/squarebox-update.sh` | In-container tool updater (`sqrbx-update`) |
 | `scripts/update-versions.sh` | Fetches latest Dockerfile-tier releases and updates checksums |
 | `checksums.txt` | SHA256 checksums for Dockerfile binary tools |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Prerequisites
 
 - [Docker](https://docs.docker.com/get-docker/) (see one-line install below if you don't have it)
 - [Git](https://git-scm.com/) - on Windows, install [Git for Windows](https://gitforwindows.org/)
-  (provides `bash` and `winpty` needed by the install script)
 
 ### Don't have Docker? One-line install
 
@@ -68,8 +67,9 @@ If the install fails or you want to see the full docker build and git output, re
 
 **Windows (PowerShell 7+)**
 
-Windows users can install directly from PowerShell, which also sets up
-PowerShell aliases (`sqrbx`, `squarebox`, etc.):
+Windows users can install directly from PowerShell — no Git Bash required.
+This handles clone, build, container creation, and PowerShell aliases
+(`sqrbx`, `squarebox`, etc.) natively:
 
     irm https://raw.githubusercontent.com/SquareWaveSystems/squarebox/main/install.ps1 | iex
 
@@ -82,9 +82,6 @@ Once installed, you can re-run or pass flags from the local copy:
 > **Note:** `irm ... | iex` does not support flags — PowerShell interprets them
 > as arguments to `Invoke-Expression`, not the script. Use the local
 > `.\install.ps1` form for `-Edge` or `-Verbose`.
-
-This runs `install.sh` via Git Bash under the hood and then writes the
-PowerShell profile.
 
 Start
 -----

--- a/install.ps1
+++ b/install.ps1
@@ -1,16 +1,15 @@
 #!/usr/bin/env pwsh
 <#
 .SYNOPSIS
-    Windows installer for squarebox. Writes PowerShell profile aliases
-    and delegates Docker/bash setup to install.sh via Git Bash.
+    Windows installer for squarebox. Pure PowerShell — no Git Bash required.
 .DESCRIPTION
-    Run this from PowerShell 7+ to install squarebox with working PowerShell
-    aliases. Equivalent to running install.sh from Git Bash, but also sets up
-    your PowerShell profile so sqrbx/squarebox commands work in PowerShell.
+    Run this from PowerShell 7+ to install squarebox. Handles clone, build,
+    container creation, and PowerShell profile setup natively.
 
     First install:  irm https://raw.githubusercontent.com/SquareWaveSystems/squarebox/main/install.ps1 | iex
     Re-install:     .\install.ps1
     Edge:           .\install.ps1 -Edge
+    Verbose:        .\install.ps1 -Verbose
 #>
 #Requires -Version 7.0
 
@@ -21,51 +20,143 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-# --- Find Git Bash ---
-$bashCandidates = @(
-    "$env:PROGRAMFILES\Git\bin\bash.exe"
-    "${env:PROGRAMFILES(x86)}\Git\bin\bash.exe"
-)
-$gcm = Get-Command bash.exe -ErrorAction SilentlyContinue
-if ($gcm) { $bashCandidates += $gcm.Source }
+$Repo        = 'https://github.com/SquareWaveSystems/squarebox.git'
+$InstallDir  = Join-Path $env:USERPROFILE 'squarebox'
+$ImageName   = 'squarebox'
+$ContainerName = 'squarebox'
 
-$bash = $bashCandidates | Where-Object { $_ -and (Test-Path $_) } |
-    Select-Object -First 1
-if (-not $bash) {
-    Write-Error "Git Bash not found. Install Git for Windows: https://git-scm.com/download/win"
+# --- Verify prerequisites ---
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    Write-Error "Git is not installed. See https://git-scm.com/download/win"
+    exit 1
+}
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+    Write-Error "Docker is not installed. See https://docs.docker.com/get-docker/"
+    exit 1
+}
+try { docker info 2>$null | Out-Null } catch {}
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Docker daemon is not running or current user lacks permissions."
     exit 1
 }
 
-# --- Run install.sh (clone, build, container, bash profile) ---
-# Use --login so Git Bash sources /etc/profile, which adds /usr/bin to PATH.
-# Without this, cygpath and other MSYS2 tools may not be available when bash
-# is invoked non-interactively from PowerShell.
-$installArgs = @('--no-pwsh')
-if ($Edge)    { $installArgs += '--edge' }
-if ($Verbose) { $installArgs += '--verbose' }
-
-$InstallDir = Join-Path $env:USERPROFILE 'squarebox'
-$installSh  = Join-Path $InstallDir 'install.sh'
-
-if (Test-Path $installSh) {
-    & $bash --login $installSh @installArgs
+# --- Clone or update ---
+if (Test-Path (Join-Path $InstallDir '.git')) {
+    Write-Host "Updating existing install..."
+    $gitQuiet = if ($Verbose) { @() } else { @('--quiet') }
+    git -C $InstallDir fetch --tags --force @gitQuiet origin
 } else {
-    # First install: download install.sh to a temp file and execute it.
-    # Piping a string through PowerShell to bash can introduce CRLF / encoding
-    # changes that break bash parsing. Using a temp file keeps the script
-    # byte-identical to what the server sent.
-    $url = 'https://raw.githubusercontent.com/SquareWaveSystems/squarebox/main/install.sh'
-    $tmp = Join-Path ([System.IO.Path]::GetTempPath()) 'squarebox-install.sh'
-    try {
-        Invoke-WebRequest -Uri $url -UseBasicParsing -OutFile $tmp
-        & $bash --login $tmp @installArgs
-    } finally {
-        Remove-Item $tmp -ErrorAction SilentlyContinue
+    Write-Host "Cloning squarebox..."
+    $gitQuiet = if ($Verbose) { @() } else { @('--quiet') }
+    git clone @gitQuiet $Repo $InstallDir
+}
+
+# --- Select version ---
+if ($Edge) {
+    Write-Host "Using latest main (edge)..."
+    git -C $InstallDir checkout main --quiet
+    git -C $InstallDir reset --hard --quiet origin/main
+} else {
+    $latestTag = git -C $InstallDir tag --sort=-v:refname |
+        Where-Object { $_ -notmatch '-rc' } |
+        Select-Object -First 1
+    if ($latestTag) {
+        Write-Host "Using release $latestTag..."
+        git -C $InstallDir checkout $latestTag --quiet
+    } else {
+        Write-Host "No releases found, using main branch..."
+        git -C $InstallDir checkout main --quiet
+        git -C $InstallDir reset --hard --quiet origin/main
     }
 }
+
+# --- Build ---
+Write-Host "Building image... " -NoNewline
+if ($Verbose) {
+    Write-Host ""
+    docker build -t $ImageName $InstallDir
+} else {
+    $buildLog = docker build -t $ImageName $InstallDir 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "FAILED" -ForegroundColor Red
+        Write-Error "Build output:`n$($buildLog -join "`n")"
+        exit 1
+    }
+    Write-Host "done"
+}
+
+# --- Remove old container ---
+$existing = docker ps -a --format '{{.Names}}' | Where-Object { $_ -eq $ContainerName }
+if ($existing) {
+    Write-Host "Removing old container..."
+    docker stop $ContainerName 2>$null | Out-Null
+    docker rm $ContainerName | Out-Null
+}
+
+# --- Propagate host git identity ---
+$gitCfgDir = Join-Path $env:USERPROFILE '.config\git'
+if (-not (Test-Path $gitCfgDir)) { New-Item -ItemType Directory -Path $gitCfgDir -Force | Out-Null }
+$gitCfgFile = Join-Path $gitCfgDir 'config'
+
+$hostName  = git config --global user.name 2>$null
+$hostEmail = git config --global user.email 2>$null
+if ($hostName)  { git config --file $gitCfgFile user.name $hostName }
+if ($hostEmail) { git config --file $gitCfgFile user.email $hostEmail }
+
+# --- Seed default configs ---
+$configDir = Join-Path $InstallDir '.config'
+$workspaceDir = Join-Path $InstallDir 'workspace'
+foreach ($dir in @($configDir, $workspaceDir)) {
+    if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+}
+
+$starshipDest = Join-Path $configDir 'starship.toml'
+if (-not (Test-Path $starshipDest)) {
+    Copy-Item (Join-Path $InstallDir 'starship.toml') $starshipDest
+}
+
+$lazygitDir = Join-Path $configDir 'lazygit'
+if (-not (Test-Path $lazygitDir)) { New-Item -ItemType Directory -Path $lazygitDir -Force | Out-Null }
+$lazygitCfg = Join-Path $lazygitDir 'config.yml'
+if (-not (Test-Path $lazygitCfg)) {
+    @"
+git:
+  paging:
+    colorArg: always
+    pager: delta --dark --paging=never
+"@ | Set-Content -Path $lazygitCfg
+}
+
+# --- Create container ---
+Write-Host "Creating container..."
+
+$dockerVolumes = @(
+    '-v', "$workspaceDir`:/workspace"
+    '-v', "$gitCfgDir`:/home/dev/.config/git"
+    '-v', "${starshipDest}:/home/dev/.config/starship.toml"
+    '-v', "${lazygitDir}:/home/dev/.config/lazygit"
+)
+
+# SSH: mount ~/.ssh read-only so git/ssh inside the container can use the
+# host's keys and config. Windows named-pipe agent forwarding (\\.\pipe\...)
+# into a Linux container's Unix socket is not reliably supported by Docker
+# Desktop, so we don't attempt pipe forwarding — keys are available directly.
+$sshDir = Join-Path $env:USERPROFILE '.ssh'
+if (Test-Path $sshDir) {
+    $dockerVolumes += @('-v', "${sshDir}:/home/dev/.ssh:ro")
+}
+
+# Drop all capabilities except those needed for scoped sudo
+$dockerOpts = @(
+    '--cap-drop=ALL'
+    '--cap-add=CHOWN', '--cap-add=DAC_OVERRIDE', '--cap-add=FOWNER'
+    '--cap-add=SETUID', '--cap-add=SETGID', '--cap-add=KILL'
+)
+
+$createResult = docker create -it --name $ContainerName @dockerOpts @dockerVolumes $ImageName 2>&1
 if ($LASTEXITCODE -ne 0) {
-    Write-Error "install.sh failed (exit code $LASTEXITCODE)"
-    exit $LASTEXITCODE
+    Write-Error "Failed to create container '$ContainerName':`n$createResult"
+    exit 1
 }
 
 # --- PowerShell profile setup ---
@@ -89,16 +180,26 @@ if (Test-Path $PROFILE) {
     Set-Content -Path $PROFILE -Value ($filtered -join "`n")
 }
 
-# Append managed block
-@'
+# Append managed block. Use a single-quoted here-string so $PROFILE variables
+# like @args aren't expanded at install time, then substitute the install path.
+$profileBlock = @'
 # >>> squarebox >>>
-# squarebox shell integration — managed by install.ps1.
+# squarebox shell integration - managed by install.ps1.
 Remove-Item Alias:sqrbx, Alias:squarebox, Alias:sqrbx-rebuild, Alias:squarebox-rebuild -ErrorAction SilentlyContinue
 function sqrbx { docker start -ai squarebox }
 function squarebox { docker start -ai squarebox }
-function sqrbx-rebuild { & "$env:USERPROFILE\squarebox\install.ps1" @args }
+function sqrbx-rebuild { & "__INSTALL_DIR__\install.ps1" @args }
 function squarebox-rebuild { sqrbx-rebuild @args }
 # <<< squarebox <<<
-'@ | Add-Content -Path $PROFILE
+'@
+$profileBlock = $profileBlock -replace '__INSTALL_DIR__', $InstallDir
+$profileBlock | Add-Content -Path $PROFILE
 
 Write-Host "Installed squarebox shell integration -> $PROFILE"
+
+# --- Start container ---
+if ([System.Console]::IsInputRedirected) {
+    Write-Host "Install complete. Run 'squarebox' (or 'sqrbx') to start."
+} else {
+    docker start -ai $ContainerName
+}

--- a/install.ps1
+++ b/install.ps1
@@ -25,37 +25,45 @@ $InstallDir  = Join-Path $env:USERPROFILE 'squarebox'
 $ImageName   = 'squarebox'
 $ContainerName = 'squarebox'
 
-# --- Verify prerequisites ---
-if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
-    Write-Error "Git is not installed. See https://git-scm.com/download/win"
-    exit 1
-}
-if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
-    Write-Error "Docker is not installed. See https://docs.docker.com/get-docker/"
-    exit 1
-}
-try { docker info 2>$null | Out-Null } catch {}
-if ($LASTEXITCODE -ne 0) {
-    Write-Error "Docker daemon is not running or current user lacks permissions."
+# Write-Error with $ErrorActionPreference='Stop' becomes a terminating error
+# before exit runs, showing an ugly exception trace. This helper prints a clean
+# error message and exits with code 1.
+function Abort([string]$msg) {
+    Write-Host "Error: $msg" -ForegroundColor Red
     exit 1
 }
 
+# --- Verify prerequisites ---
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    Abort "Git is not installed. See https://git-scm.com/download/win"
+}
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+    Abort "Docker is not installed. See https://docs.docker.com/get-docker/"
+}
+try { docker info 2>$null | Out-Null } catch {}
+if ($LASTEXITCODE -ne 0) {
+    Abort "Docker daemon is not running or current user lacks permissions."
+}
+
 # --- Clone or update ---
+$gitQuiet = if ($Verbose) { @() } else { @('--quiet') }
 if (Test-Path (Join-Path $InstallDir '.git')) {
     Write-Host "Updating existing install..."
-    $gitQuiet = if ($Verbose) { @() } else { @('--quiet') }
     git -C $InstallDir fetch --tags --force @gitQuiet origin
+    if ($LASTEXITCODE -ne 0) { Abort "git fetch failed." }
 } else {
     Write-Host "Cloning squarebox..."
-    $gitQuiet = if ($Verbose) { @() } else { @('--quiet') }
     git clone @gitQuiet $Repo $InstallDir
+    if ($LASTEXITCODE -ne 0) { Abort "git clone failed." }
 }
 
 # --- Select version ---
 if ($Edge) {
     Write-Host "Using latest main (edge)..."
     git -C $InstallDir checkout main --quiet
+    if ($LASTEXITCODE -ne 0) { Abort "git checkout main failed." }
     git -C $InstallDir reset --hard --quiet origin/main
+    if ($LASTEXITCODE -ne 0) { Abort "git reset failed." }
 } else {
     $latestTag = git -C $InstallDir tag --sort=-v:refname |
         Where-Object { $_ -notmatch '-rc' } |
@@ -63,10 +71,13 @@ if ($Edge) {
     if ($latestTag) {
         Write-Host "Using release $latestTag..."
         git -C $InstallDir checkout $latestTag --quiet
+        if ($LASTEXITCODE -ne 0) { Abort "git checkout $latestTag failed." }
     } else {
         Write-Host "No releases found, using main branch..."
         git -C $InstallDir checkout main --quiet
+        if ($LASTEXITCODE -ne 0) { Abort "git checkout main failed." }
         git -C $InstallDir reset --hard --quiet origin/main
+        if ($LASTEXITCODE -ne 0) { Abort "git reset failed." }
     }
 }
 
@@ -75,12 +86,13 @@ Write-Host "Building image... " -NoNewline
 if ($Verbose) {
     Write-Host ""
     docker build -t $ImageName $InstallDir
+    if ($LASTEXITCODE -ne 0) { Abort "Docker build failed." }
 } else {
     $buildLog = docker build -t $ImageName $InstallDir 2>&1
     if ($LASTEXITCODE -ne 0) {
         Write-Host "FAILED" -ForegroundColor Red
-        Write-Error "Build output:`n$($buildLog -join "`n")"
-        exit 1
+        Write-Host ($buildLog -join "`n")
+        Abort "Docker build failed."
     }
     Write-Host "done"
 }
@@ -155,8 +167,7 @@ $dockerOpts = @(
 
 $createResult = docker create -it --name $ContainerName @dockerOpts @dockerVolumes $ImageName 2>&1
 if ($LASTEXITCODE -ne 0) {
-    Write-Error "Failed to create container '$ContainerName':`n$createResult"
-    exit 1
+    Abort "Failed to create container '$ContainerName':`n$createResult"
 }
 
 # --- PowerShell profile setup ---

--- a/install.sh
+++ b/install.sh
@@ -54,13 +54,11 @@ IMAGE_NAME="squarebox"
 CONTAINER_NAME="squarebox"
 EDGE="${SQUAREBOX_EDGE:-0}"
 VERBOSE=0
-NO_PWSH=0
 
 for arg in "$@"; do
 	case "$arg" in
 		--edge) EDGE=1 ;;
 		--verbose) VERBOSE=1 ;;
-		--no-pwsh) NO_PWSH=1 ;;
 	esac
 done
 
@@ -230,13 +228,14 @@ if [[ -n "${MSYSTEM:-}" ]] && [[ "${SHELL_RC}" == *".bashrc" ]]; then
 	fi
 fi
 
-# PowerShell 7+ profile (Windows). install.ps1 handles this natively — it
-# writes the profile using $PROFILE directly (no cross-shell detection needed).
-# When invoked with --no-pwsh (by install.ps1), skip this entirely.
-if [ "$NO_PWSH" != 1 ] && { [ -n "${MSYSTEM:-}" ] || [ -n "${USERPROFILE:-}" ]; }; then
+# PowerShell 7+ profile (Windows). install.ps1 handles everything natively
+# (clone, build, container, profile) — no Git Bash needed. If the user ran
+# install.sh directly from Git Bash, nudge them toward install.ps1 for
+# PowerShell integration.
+if [ -n "${MSYSTEM:-}" ] || [ -n "${USERPROFILE:-}" ]; then
 	_ps1_path="$(cygpath -w "${INSTALL_DIR}/install.ps1" 2>/dev/null || echo "${INSTALL_DIR}\\install.ps1")"
 	echo ""
-	echo "PowerShell: to add squarebox aliases to your PowerShell profile, run:"
+	echo "PowerShell: for native PowerShell support (no Git Bash needed), run:"
 	echo "  pwsh -File \"${_ps1_path}\""
 	echo ""
 fi


### PR DESCRIPTION
## Summary

- Rewrites `install.ps1` from a thin Git Bash wrapper into a standalone PowerShell installer that natively handles clone, build, container creation, volume mounts, git identity propagation, config seeding, and profile setup — **removing the Git Bash dependency for Windows/PowerShell users**
- Removes the `--no-pwsh` flag from `install.sh` (no longer called by `install.ps1`) and updates the PowerShell hint message for users who run `install.sh` directly from Git Bash
- Mounts `~/.ssh` read-only instead of attempting Windows named-pipe agent forwarding (not reliably supported by Docker Desktop for Linux containers)

## Test plan

- [ ] Run `install.ps1` on Windows with PowerShell 7+ (fresh install — no existing `~/squarebox`)
- [ ] Run `install.ps1 -Edge` on Windows (update existing install)
- [ ] Run `install.ps1 -Verbose` and verify build output is shown
- [ ] Verify `sqrbx` / `squarebox` aliases work in PowerShell after install
- [ ] Verify `sqrbx-rebuild` calls `install.ps1` correctly
- [ ] Run `install.sh` from Git Bash and verify it still works independently
- [ ] Verify SSH keys are available inside the container (git clone from private repo)
- [ ] Verify git identity is propagated into container

🤖 Generated with [Claude Code](https://claude.com/claude-code)