### PR TITLE
feat: add Podman compatibility as drop-in alternative to Docker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-squarebox is a containerized development environment (Docker) combining modern CLI/TUI tools with Claude Code. It uses a persistent container model — the container suspends on exit and resumes on restart, preserving state. Workspace code lives on the host at `~/squarebox/workspace` via volume mount.
+squarebox is a containerized development environment (Docker or Podman) combining modern CLI/TUI tools with Claude Code. It uses a persistent container model — the container suspends on exit and resumes on restart, preserving state. Workspace code lives on the host at `~/squarebox/workspace` via volume mount.
 
 ## Build & Run
 
 ```bash
-# Build the Docker image
+# Build the image (docker or podman — both work)
 docker build -t squarebox .
 
 # Create and run a new container (SSH agent forwarding, capability-restricted)
@@ -30,6 +30,8 @@ docker run -it --name squarebox \
 # Resume an existing container
 docker start -ai squarebox
 ```
+
+Replace `docker` with `podman` above if using Podman. The `install.sh` script auto-detects the runtime; override with `SQUAREBOX_RUNTIME=docker|podman`.
 
 The `install.sh` script automates initial setup (clone, build, create container, add `sqrbx` shell alias). A `.devcontainer/devcontainer.json` is also provided for VS Code Dev Containers / Codespaces.
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # 🟧📦 squarebox
 
-**A curated set of modern CLI/TUI tools and AI coding assistants in a Docker container. Batteries included.**
+**A curated set of modern CLI/TUI tools and AI coding assistants in a container. Batteries included.**
 
 *For developers who live in the terminal but need to work across
 multiple platforms and devices.*
 
 **squarebox** packages a complete terminal-based development environment
-into a single Docker container: modern CLI tools, AI coding assistants,
-language SDKs, and an opinionated set of shell aliases. Run the same box
-anywhere (desktop, VPS, or Codespace) and SSH in from your laptop, tablet,
-or phone (please don't).
+into a single container (Docker or Podman): modern CLI tools, AI coding
+assistants, language SDKs, and an opinionated set of shell aliases. Run the
+same box anywhere (desktop, VPS, or Codespace) and SSH in from your laptop,
+tablet, or phone (please don't).
 
 The goal is to make modern terminal tooling easy and accessible. One-line
 install, interactive first-run setup, sensible defaults (thanks [omarchy](https://omarchy.org)).
@@ -20,10 +20,14 @@ install, interactive first-run setup, sensible defaults (thanks [omarchy](https:
 Prerequisites
 -------------
 
-- [Docker](https://docs.docker.com/get-docker/) (see one-line install below if you don't have it)
+- [Docker](https://docs.docker.com/get-docker/) or [Podman](https://podman.io/getting-started/installation) (see one-line install below if you don't have either)
 - [Git](https://git-scm.com/) - on Windows, install [Git for Windows](https://gitforwindows.org/)
 
-### Don't have Docker? One-line install
+The installer auto-detects which runtime is available. If both are installed, it
+asks which to use. Override with `SQUAREBOX_RUNTIME=docker` or
+`SQUAREBOX_RUNTIME=podman`.
+
+### Don't have Docker or Podman? One-line install
 
 **macOS** (via [Homebrew](https://brew.sh)):
 
@@ -45,7 +49,7 @@ running before you continue.
 Install
 -------
 
-These commands clone the repo, build the Docker image, and drop you into the
+These commands clone the repo, build the container image, and drop you into the
 container (if possible). On first login, a setup script runs automatically to
 configure git (pulling your name and email from the host's global git config
 if available), optionally sign in to GitHub CLI, your choice of AI coding
@@ -88,8 +92,9 @@ Start
 
     squarebox        # or: sqrbx
 
-These are shell aliases for `docker start -ai squarebox`, added automatically
-for Bash, Zsh, and PowerShell 7+.
+These are shell functions wrapping `docker start -ai squarebox` (or
+`podman start -ai squarebox`), added automatically for Bash, Zsh, and
+PowerShell 7+.
 
 The container is persistent: it suspends on exit and resumes on start, keeping
 installed packages, config, and shell history intact between sessions. Your

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,4 +21,4 @@ Items are listed in priority order.
 - **Network firewall / sandboxing mode** — optional network-level isolation (iptables/seccomp) so AI agents can only reach approved endpoints, inspired by trailofbits and clampdown
 - **Multiple concurrent container instances** — support running more than one squarebox container simultaneously
 - **Multi-agent workflow orchestration** — explore adding a layer to run multiple AI coding agents simultaneously in isolated contexts (git worktrees + tmux sessions), inspired by agent-of-empires; may be better to integrate an existing tool than build from scratch
-- **Podman compatibility** — support Podman as a drop-in alternative to Docker for building and running squarebox containers
+- ~~**Podman compatibility**~~ — ✅ done: install scripts auto-detect Docker or Podman and skip UID chown logic for Podman's rootless user namespace mapping

--- a/install.ps1
+++ b/install.ps1
@@ -37,13 +37,31 @@ function Abort([string]$msg) {
 if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
     Abort "Git is not installed. See https://git-scm.com/download/win"
 }
-if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
-    Abort "Docker is not installed. See https://docs.docker.com/get-docker/"
+# Detect container runtime. Override with $env:SQUAREBOX_RUNTIME.
+$hasDocker = [bool](Get-Command docker -ErrorAction SilentlyContinue)
+$hasPodman = [bool](Get-Command podman -ErrorAction SilentlyContinue)
+
+if ($env:SQUAREBOX_RUNTIME) {
+    $Runtime = $env:SQUAREBOX_RUNTIME
+} elseif ($hasDocker -and $hasPodman) {
+    Write-Host "Both Docker and Podman detected."
+    Write-Host "  1) Docker"
+    Write-Host "  2) Podman"
+    $choice = Read-Host "Which runtime? [1]"
+    $Runtime = if ($choice -eq '2') { 'podman' } else { 'docker' }
+} elseif ($hasDocker) {
+    $Runtime = 'docker'
+} elseif ($hasPodman) {
+    $Runtime = 'podman'
+} else {
+    Abort "Neither Docker nor Podman is installed. See https://docs.docker.com/get-docker/ or https://podman.io"
 }
-try { docker info 2>$null | Out-Null } catch {}
+
+try { & $Runtime info 2>$null | Out-Null } catch {}
 if ($LASTEXITCODE -ne 0) {
-    Abort "Docker daemon is not running or current user lacks permissions."
+    Abort "$Runtime is not running or current user lacks permissions."
 }
+Write-Host "Using $Runtime as container runtime."
 
 # --- Clone or update ---
 $gitQuiet = if ($Verbose) { @() } else { @('--quiet') }
@@ -85,24 +103,24 @@ if ($Edge) {
 Write-Host "Building image... " -NoNewline
 if ($Verbose) {
     Write-Host ""
-    docker build -t $ImageName $InstallDir
-    if ($LASTEXITCODE -ne 0) { Abort "Docker build failed." }
+    & $Runtime build -t $ImageName $InstallDir
+    if ($LASTEXITCODE -ne 0) { Abort "$Runtime build failed." }
 } else {
-    $buildLog = docker build -t $ImageName $InstallDir 2>&1
+    $buildLog = & $Runtime build -t $ImageName $InstallDir 2>&1
     if ($LASTEXITCODE -ne 0) {
         Write-Host "FAILED" -ForegroundColor Red
         Write-Host ($buildLog -join "`n")
-        Abort "Docker build failed."
+        Abort "$Runtime build failed."
     }
     Write-Host "done"
 }
 
 # --- Remove old container ---
-$existing = docker ps -a --format '{{.Names}}' | Where-Object { $_ -eq $ContainerName }
+$existing = & $Runtime ps -a --format '{{.Names}}' | Where-Object { $_ -eq $ContainerName }
 if ($existing) {
     Write-Host "Removing old container..."
-    docker stop $ContainerName 2>$null | Out-Null
-    docker rm $ContainerName | Out-Null
+    & $Runtime stop $ContainerName 2>$null | Out-Null
+    & $Runtime rm $ContainerName | Out-Null
 }
 
 # --- Propagate host git identity ---
@@ -142,7 +160,7 @@ git:
 # --- Create container ---
 Write-Host "Creating container..."
 
-$dockerVolumes = @(
+$rtVolumes = @(
     '-v', "$workspaceDir`:/workspace"
     '-v', "$gitCfgDir`:/home/dev/.config/git"
     '-v', "${starshipDest}:/home/dev/.config/starship.toml"
@@ -151,21 +169,21 @@ $dockerVolumes = @(
 
 # SSH: mount ~/.ssh read-only so git/ssh inside the container can use the
 # host's keys and config. Windows named-pipe agent forwarding (\\.\pipe\...)
-# into a Linux container's Unix socket is not reliably supported by Docker
-# Desktop, so we don't attempt pipe forwarding — keys are available directly.
+# into a Linux container's Unix socket is not reliably supported, so we don't
+# attempt pipe forwarding — keys are available directly.
 $sshDir = Join-Path $env:USERPROFILE '.ssh'
 if (Test-Path $sshDir) {
-    $dockerVolumes += @('-v', "${sshDir}:/home/dev/.ssh:ro")
+    $rtVolumes += @('-v', "${sshDir}:/home/dev/.ssh:ro")
 }
 
 # Drop all capabilities except those needed for scoped sudo
-$dockerOpts = @(
+$rtOpts = @(
     '--cap-drop=ALL'
     '--cap-add=CHOWN', '--cap-add=DAC_OVERRIDE', '--cap-add=FOWNER'
     '--cap-add=SETUID', '--cap-add=SETGID', '--cap-add=KILL'
 )
 
-$createResult = docker create -it --name $ContainerName @dockerOpts @dockerVolumes $ImageName 2>&1
+$createResult = & $Runtime create -it --name $ContainerName @rtOpts @rtVolumes $ImageName 2>&1
 if ($LASTEXITCODE -ne 0) {
     Abort "Failed to create container '$ContainerName':`n$createResult"
 }
@@ -197,13 +215,14 @@ $profileBlock = @'
 # >>> squarebox >>>
 # squarebox shell integration - managed by install.ps1.
 Remove-Item Alias:sqrbx, Alias:squarebox, Alias:sqrbx-rebuild, Alias:squarebox-rebuild -ErrorAction SilentlyContinue
-function sqrbx { docker start -ai squarebox }
-function squarebox { docker start -ai squarebox }
+function sqrbx { & __RUNTIME__ start -ai squarebox }
+function squarebox { & __RUNTIME__ start -ai squarebox }
 function sqrbx-rebuild { & "__INSTALL_DIR__\install.ps1" @args }
 function squarebox-rebuild { sqrbx-rebuild @args }
 # <<< squarebox <<<
 '@
 $profileBlock = $profileBlock -replace '__INSTALL_DIR__', $InstallDir
+$profileBlock = $profileBlock -replace '__RUNTIME__', $Runtime
 $profileBlock | Add-Content -Path $PROFILE
 
 Write-Host "Installed squarebox shell integration -> $PROFILE"
@@ -212,5 +231,5 @@ Write-Host "Installed squarebox shell integration -> $PROFILE"
 if ([System.Console]::IsInputRedirected) {
     Write-Host "Install complete. Run 'squarebox' (or 'sqrbx') to start."
 } else {
-    docker start -ai $ContainerName
+    & $Runtime start -ai $ContainerName
 }

--- a/install.ps1
+++ b/install.ps1
@@ -42,7 +42,13 @@ $hasDocker = [bool](Get-Command docker -ErrorAction SilentlyContinue)
 $hasPodman = [bool](Get-Command podman -ErrorAction SilentlyContinue)
 
 if ($env:SQUAREBOX_RUNTIME) {
+    if ($env:SQUAREBOX_RUNTIME -notin @('docker', 'podman')) {
+        Abort "SQUAREBOX_RUNTIME must be 'docker' or 'podman' (got '$($env:SQUAREBOX_RUNTIME)')."
+    }
     $Runtime = $env:SQUAREBOX_RUNTIME
+    if (-not (Get-Command $Runtime -ErrorAction SilentlyContinue)) {
+        Abort "SQUAREBOX_RUNTIME=$Runtime but '$Runtime' is not installed."
+    }
 } elseif ($hasDocker -and $hasPodman) {
     Write-Host "Both Docker and Podman detected."
     Write-Host "  1) Docker"

--- a/install.sh
+++ b/install.sh
@@ -4,26 +4,26 @@ set -euo pipefail
 REPO="https://github.com/SquareWaveSystems/squarebox.git"
 
 # On MSYS2/Git Bash, automatic path conversion mangles the ":" separator in
-# Docker volume mounts (-v host:container), causing mounts to point to wrong
-# locations. MSYS_NO_PATHCONV disables this for docker commands.
-docker_cmd() {
+# volume mounts (-v host:container), causing mounts to point to wrong
+# locations. MSYS_NO_PATHCONV disables this for container runtime commands.
+rt_cmd() {
     if [[ -n "${MSYSTEM:-}" ]]; then
-        MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' docker "$@"
+        MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' "$RUNTIME" "$@"
     else
-        docker "$@"
+        "$RUNTIME" "$@"
     fi
 }
 
-# On Windows/mintty (Git Bash), docker needs winpty for interactive TTY
-# passthrough. mintty uses named pipes instead of the Windows Console API,
-# which breaks interactive docker commands. winpty bridges the gap.
+# On Windows/mintty (Git Bash), the container runtime needs winpty for
+# interactive TTY passthrough. mintty uses named pipes instead of the Windows
+# Console API, which breaks interactive commands. winpty bridges the gap.
 # PowerShell and CMD work natively — this only activates in MSYS2/mintty.
-docker_interactive() {
+rt_interactive() {
     if [[ -n "${MSYSTEM:-}" || "${TERM_PROGRAM:-}" == "mintty" ]] \
         && command -v winpty &>/dev/null; then
-        MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' winpty docker "$@"
+        MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' winpty "$RUNTIME" "$@"
     else
-        docker "$@"
+        "$RUNTIME" "$@"
     fi
 }
 
@@ -94,13 +94,40 @@ else
 	fi
 fi
 
-# Verify Docker is available
-if ! command -v docker &>/dev/null; then
-	echo "Error: Docker is not installed. See https://docs.docker.com/get-docker/" >&2
+# Detect container runtime. Override with SQUAREBOX_RUNTIME=docker|podman.
+_has_docker=0; command -v docker &>/dev/null && _has_docker=1
+_has_podman=0; command -v podman &>/dev/null && _has_podman=1
+
+if [ -n "${SQUAREBOX_RUNTIME:-}" ]; then
+	RUNTIME="$SQUAREBOX_RUNTIME"
+elif [ "$_has_docker" = 1 ] && [ "$_has_podman" = 1 ]; then
+	if [ -t 0 ]; then
+		echo "Both Docker and Podman detected."
+		echo "  1) Docker"
+		echo "  2) Podman"
+		printf "Which runtime? [1]: "
+		read -r _choice
+		case "$_choice" in
+			2) RUNTIME="podman" ;;
+			*) RUNTIME="docker" ;;
+		esac
+	else
+		RUNTIME="docker"
+	fi
+elif [ "$_has_docker" = 1 ]; then
+	RUNTIME="docker"
+elif [ "$_has_podman" = 1 ]; then
+	RUNTIME="podman"
+else
+	echo "Error: Neither Docker nor Podman is installed." >&2
+	echo "  Docker: https://docs.docker.com/get-docker/" >&2
+	echo "  Podman: https://podman.io/getting-started/installation" >&2
 	exit 1
 fi
-if ! docker_cmd info &>/dev/null; then
-	echo "Error: Docker daemon is not running or current user lacks permissions." >&2
+
+# Verify runtime is functional
+if ! rt_cmd info &>/dev/null; then
+	echo "Error: $RUNTIME is not running or current user lacks permissions." >&2
 	exit 1
 fi
 
@@ -111,10 +138,10 @@ _create_log=""
 trap 'rm -f "$_build_log" "$_rc_tmp" "$_create_log" 2>/dev/null || true' EXIT
 if [ "$VERBOSE" = 1 ]; then
 	echo "Building image..."
-	docker_cmd build -t "$IMAGE_NAME" "$INSTALL_DIR"
+	rt_cmd build -t "$IMAGE_NAME" "$INSTALL_DIR"
 else
 	printf "Building image... "
-	if docker_cmd build -t "$IMAGE_NAME" "$INSTALL_DIR" > "$_build_log" 2>&1; then
+	if rt_cmd build -t "$IMAGE_NAME" "$INSTALL_DIR" > "$_build_log" 2>&1; then
 		echo "done"
 	else
 		echo "FAILED" >&2
@@ -125,10 +152,10 @@ else
 fi
 
 # Remove old container if it exists
-if docker_cmd ps -a --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
+if rt_cmd ps -a --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
 	echo "Removing old container..."
-	docker_cmd stop "$CONTAINER_NAME" >/dev/null 2>&1 || true
-	docker_cmd rm "$CONTAINER_NAME" >/dev/null
+	rt_cmd stop "$CONTAINER_NAME" >/dev/null 2>&1 || true
+	rt_cmd rm "$CONTAINER_NAME" >/dev/null
 fi
 
 # Shell config must go where bash/zsh actually reads from ($HOME), which may
@@ -167,7 +194,7 @@ cat > "$SQRBX_INIT" <<SQRBXEOF
 # Managed by squarebox install.sh — overwritten on every install.
 # Drop any stale aliases with these names so they don't shadow the functions.
 unalias sqrbx squarebox sqrbx-rebuild squarebox-rebuild 2>/dev/null || true
-sqrbx() { if command -v winpty &>/dev/null && [[ -n "\${MSYSTEM:-}" ]]; then winpty docker start -ai squarebox; else docker start -ai squarebox; fi; }
+sqrbx() { if command -v winpty &>/dev/null && [[ -n "\${MSYSTEM:-}" ]]; then winpty $RUNTIME start -ai squarebox; else $RUNTIME start -ai squarebox; fi; }
 squarebox() { sqrbx "\$@"; }
 sqrbx-rebuild() { "${INSTALL_DIR}/install.sh" "\$@"; }
 squarebox-rebuild() { sqrbx-rebuild "\$@"; }
@@ -251,7 +278,8 @@ mkdir -p "${USER_HOME}/.config/git" "${INSTALL_DIR}/workspace" "${INSTALL_DIR}/.
 # to from install.sh, and INSTALL_DIR/.config writes further down are all
 # guarded by `[ ! -f ]` so only fire on first install where we just mkdir'd
 # the dir as the current user. The final chown-to-1000 still runs further down.
-if [ "$(uname -s)" = "Linux" ] && [ "$(id -u)" -ne 1000 ] && [ ! -w "${USER_HOME}/.config/git" ]; then
+# Podman: rootless Podman maps UIDs via user namespaces, so this is unnecessary.
+if [ "$RUNTIME" = "docker" ] && [ "$(uname -s)" = "Linux" ] && [ "$(id -u)" -ne 1000 ] && [ ! -w "${USER_HOME}/.config/git" ]; then
 	if [ "$(id -u)" -eq 0 ]; then
 		chown -R "$(id -u):$(id -g)" "${USER_HOME}/.config/git"
 	elif command -v sudo &>/dev/null; then
@@ -303,7 +331,9 @@ fi
 # Linux-only: macOS and Windows Docker Desktop remap bind-mount ownership
 # transparently via their VMs, so chowning host dirs there is both unnecessary
 # and harmful (uid 1000 typically doesn't exist on the host).
-if [ "$(uname -s)" = "Linux" ] && [ "$(id -u)" -ne 1000 ]; then
+# Podman: rootless Podman maps UIDs via user namespaces automatically — the
+# container's uid 1000 maps to the invoking user. Chowning is unnecessary.
+if [ "$RUNTIME" = "docker" ] && [ "$(uname -s)" = "Linux" ] && [ "$(id -u)" -ne 1000 ]; then
 	_chown_paths=(
 		"${USER_HOME}/.config/git"
 		"${INSTALL_DIR}/workspace"
@@ -326,35 +356,35 @@ if [ "$(uname -s)" = "Linux" ] && [ "$(id -u)" -ne 1000 ]; then
 fi
 
 echo "Creating container..."
-DOCKER_OPTS=()
-DOCKER_VOLUMES=(
+RT_OPTS=()
+RT_VOLUMES=(
 	-v "${INSTALL_DIR}/workspace:/workspace"
 	-v "${USER_HOME}/.config/git:/home/dev/.config/git"
 	-v "${INSTALL_DIR}/.config/starship.toml:/home/dev/.config/starship.toml"
 	-v "${INSTALL_DIR}/.config/lazygit:/home/dev/.config/lazygit"
 )
 # /etc/localtime doesn't exist on Windows — only mount it on Linux/macOS
-[ -f /etc/localtime ] && DOCKER_VOLUMES+=(-v /etc/localtime:/etc/localtime:ro)
+[ -f /etc/localtime ] && RT_VOLUMES+=(-v /etc/localtime:/etc/localtime:ro)
 
 # SSH: prefer agent forwarding (private keys never enter the container).
 # Falls back to mounting ~/.ssh read-only if no agent is detected.
 if [ -n "${SSH_AUTH_SOCK:-}" ] && [ -S "$SSH_AUTH_SOCK" ]; then
-	DOCKER_VOLUMES+=(-v "$SSH_AUTH_SOCK:/tmp/ssh-agent.sock")
-	DOCKER_OPTS+=(-e SSH_AUTH_SOCK=/tmp/ssh-agent.sock)
-	[ -f "${USER_HOME}/.ssh/config" ] && DOCKER_VOLUMES+=(-v "${USER_HOME}/.ssh/config:/home/dev/.ssh/config:ro")
-	[ -f "${USER_HOME}/.ssh/known_hosts" ] && DOCKER_VOLUMES+=(-v "${USER_HOME}/.ssh/known_hosts:/home/dev/.ssh/known_hosts:ro")
+	RT_VOLUMES+=(-v "$SSH_AUTH_SOCK:/tmp/ssh-agent.sock")
+	RT_OPTS+=(-e SSH_AUTH_SOCK=/tmp/ssh-agent.sock)
+	[ -f "${USER_HOME}/.ssh/config" ] && RT_VOLUMES+=(-v "${USER_HOME}/.ssh/config:/home/dev/.ssh/config:ro")
+	[ -f "${USER_HOME}/.ssh/known_hosts" ] && RT_VOLUMES+=(-v "${USER_HOME}/.ssh/known_hosts:/home/dev/.ssh/known_hosts:ro")
 elif [ -d "${USER_HOME}/.ssh" ]; then
 	echo "Note: SSH agent not detected — mounting ~/.ssh read-only"
-	DOCKER_VOLUMES+=(-v "${USER_HOME}/.ssh:/home/dev/.ssh:ro")
+	RT_VOLUMES+=(-v "${USER_HOME}/.ssh:/home/dev/.ssh:ro")
 fi
 
 # Drop all Linux capabilities except those needed for scoped sudo
-DOCKER_OPTS+=(--cap-drop=ALL --cap-add=CHOWN --cap-add=DAC_OVERRIDE --cap-add=FOWNER --cap-add=SETUID --cap-add=SETGID --cap-add=KILL)
+RT_OPTS+=(--cap-drop=ALL --cap-add=CHOWN --cap-add=DAC_OVERRIDE --cap-add=FOWNER --cap-add=SETUID --cap-add=SETGID --cap-add=KILL)
 
 _create_log="$(mktemp)"
-if ! docker_cmd create -it --name "$CONTAINER_NAME" \
-	"${DOCKER_OPTS[@]}" \
-	"${DOCKER_VOLUMES[@]}" \
+if ! rt_cmd create -it --name "$CONTAINER_NAME" \
+	"${RT_OPTS[@]}" \
+	"${RT_VOLUMES[@]}" \
 	"$IMAGE_NAME" > "$_create_log" 2>&1; then
 	echo "Error: failed to create container '$CONTAINER_NAME'." >&2
 	cat "$_create_log" >&2
@@ -362,7 +392,7 @@ if ! docker_cmd create -it --name "$CONTAINER_NAME" \
 fi
 
 if [ -t 0 ]; then
-	docker_interactive start -ai "$CONTAINER_NAME"
+	rt_interactive start -ai "$CONTAINER_NAME"
 else
 	echo "Install complete. Run 'squarebox' (or 'sqrbx') to start (you may need to restart your shell first)."
 fi

--- a/install.sh
+++ b/install.sh
@@ -99,7 +99,14 @@ _has_docker=0; command -v docker &>/dev/null && _has_docker=1
 _has_podman=0; command -v podman &>/dev/null && _has_podman=1
 
 if [ -n "${SQUAREBOX_RUNTIME:-}" ]; then
-	RUNTIME="$SQUAREBOX_RUNTIME"
+	case "$SQUAREBOX_RUNTIME" in
+		docker|podman) RUNTIME="$SQUAREBOX_RUNTIME" ;;
+		*) echo "Error: SQUAREBOX_RUNTIME must be 'docker' or 'podman' (got '$SQUAREBOX_RUNTIME')." >&2; exit 1 ;;
+	esac
+	if ! command -v "$RUNTIME" &>/dev/null; then
+		echo "Error: SQUAREBOX_RUNTIME=$RUNTIME but '$RUNTIME' is not installed." >&2
+		exit 1
+	fi
 elif [ "$_has_docker" = 1 ] && [ "$_has_podman" = 1 ]; then
 	if [ -t 0 ]; then
 		echo "Both Docker and Podman detected."
@@ -279,7 +286,16 @@ mkdir -p "${USER_HOME}/.config/git" "${INSTALL_DIR}/workspace" "${INSTALL_DIR}/.
 # guarded by `[ ! -f ]` so only fire on first install where we just mkdir'd
 # the dir as the current user. The final chown-to-1000 still runs further down.
 # Podman: rootless Podman maps UIDs via user namespaces, so this is unnecessary.
-if [ "$RUNTIME" = "docker" ] && [ "$(uname -s)" = "Linux" ] && [ "$(id -u)" -ne 1000 ] && [ ! -w "${USER_HOME}/.config/git" ]; then
+# Rootful Podman behaves like Docker — chown is still needed.
+_needs_chown=0
+if [ "$(uname -s)" = "Linux" ] && [ "$(id -u)" -ne 1000 ]; then
+	if [ "$RUNTIME" = "docker" ]; then
+		_needs_chown=1
+	elif [ "$RUNTIME" = "podman" ] && podman info --format '{{.Host.Security.Rootless}}' 2>/dev/null | grep -qi false; then
+		_needs_chown=1
+	fi
+fi
+if [ "$_needs_chown" = 1 ] && [ ! -w "${USER_HOME}/.config/git" ]; then
 	if [ "$(id -u)" -eq 0 ]; then
 		chown -R "$(id -u):$(id -g)" "${USER_HOME}/.config/git"
 	elif command -v sudo &>/dev/null; then
@@ -333,7 +349,8 @@ fi
 # and harmful (uid 1000 typically doesn't exist on the host).
 # Podman: rootless Podman maps UIDs via user namespaces automatically — the
 # container's uid 1000 maps to the invoking user. Chowning is unnecessary.
-if [ "$RUNTIME" = "docker" ] && [ "$(uname -s)" = "Linux" ] && [ "$(id -u)" -ne 1000 ]; then
+# Rootful Podman behaves like Docker and still needs the chown.
+if [ "$_needs_chown" = 1 ]; then
 	_chown_paths=(
 		"${USER_HOME}/.config/git"
 		"${INSTALL_DIR}/workspace"


### PR DESCRIPTION
Install scripts (install.sh, install.ps1) now auto-detect whether Docker
or Podman is available. When both are present, the user is prompted to
choose; override with SQUAREBOX_RUNTIME=docker|podman. The UID chown
logic for bind mounts is skipped for Podman since rootless Podman handles
UID mapping via user namespaces automatically.

https://claude.ai/code/session_018ThhimXfRvtM2ypGxZz1d7