### PR TITLE
fix: replace array splatting with direct git calls in install.ps1

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -46,14 +46,21 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 # --- Clone or update ---
-$gitQuiet = if ($Verbose) { @() } else { @('--quiet') }
 if (Test-Path (Join-Path $InstallDir '.git')) {
     Write-Host "Updating existing install..."
-    git -C $InstallDir fetch --tags --force @gitQuiet origin
+    if ($Verbose) {
+        git -C $InstallDir fetch --tags --force origin
+    } else {
+        git -C $InstallDir fetch --tags --force --quiet origin
+    }
     if ($LASTEXITCODE -ne 0) { Abort "git fetch failed." }
 } else {
     Write-Host "Cloning squarebox..."
-    git clone @gitQuiet $Repo $InstallDir
+    if ($Verbose) {
+        git clone -- $Repo $InstallDir
+    } else {
+        git clone --quiet -- $Repo $InstallDir
+    }
     if ($LASTEXITCODE -ne 0) { Abort "git clone failed." }
 }
 


### PR DESCRIPTION
Array splatting (@gitQuiet) on native commands can break argument
quoting in PowerShell, causing "fatal: Too many arguments" when
running via `irm | iex` — especially with paths containing spaces
or on newer PowerShell versions (7.6+). Use explicit if/else
branches and add `--` separator to git clone.

https://claude.ai/code/session_01EYzo17KWG9rr2XxpzqTQao