### PR TITLE
docs: roadmap cleanup; add just and difftastic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
       - name: All tools exist
         run: |
           docker run --rm squarebox:test bash -c '
-            for cmd in bat curl delta eza fd fzf gh glow gum jq nano rg starship xh yq zoxide; do
+            for cmd in bat curl delta difft eza fd fzf gh glow gum jq just nano rg starship xh yq zoxide; do
               which "$cmd" || { echo "MISSING: $cmd"; exit 1; }
             done
           '

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ scripts/update-versions.sh
 sqrbx-update
 ```
 
-`scripts/update-versions.sh` only touches the Dockerfile tier (delta, yq, xh, glow, gum, starship). It fetches latest GitHub releases, downloads artifacts for both architectures, computes SHA256 checksums, and updates `checksums.txt` and the Dockerfile ARGs.
+`scripts/update-versions.sh` only touches the Dockerfile tier (delta, yq, xh, glow, gum, starship, just, difftastic). It fetches latest GitHub releases, downloads artifacts for both architectures, computes SHA256 checksums, and updates `checksums.txt` and the Dockerfile ARGs.
 
 Optional tools installed by `setup.sh` (opencode, editors, TUIs, zellij, Go, nvm) are not pinned. They install the latest upstream release at setup time, so there is no checksum file or version variable to update in the repo.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ To run a quick local smoke test:
 ```bash
 docker build -t squarebox:test .
 docker run --rm squarebox:test bash -c '
-  for cmd in bat curl delta eza fd fzf gh glow gum jq nano rg starship xh yq zoxide; do
+  for cmd in bat curl delta difft eza fd fzf gh glow gum jq just nano rg starship xh yq zoxide; do
     which "$cmd" || { echo "MISSING: $cmd"; exit 1; }
   done
   echo "All tools present"
@@ -65,7 +65,7 @@ docker run --rm squarebox:test bash -c '
 
 ### Adding or updating a tool
 
-Dockerfile-tier tools (delta, yq, xh, glow, gum, starship) are pinned via
+Dockerfile-tier tools (delta, yq, xh, glow, gum, starship, just, difftastic) are pinned via
 `ARG` directives and verified against `checksums.txt`. To bump them:
 
 1. Run `./scripts/update-versions.sh` to fetch latest versions and checksums

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,14 +39,18 @@ ARG XH_VERSION=0.25.3
 ARG STARSHIP_VERSION=1.24.2
 ARG GLOW_VERSION=2.1.1
 ARG GUM_VERSION=0.17.0
+ARG JUST_VERSION=1.49.0
+ARG DIFFTASTIC_VERSION=0.68.0
 
 # Validate version ARGs are non-empty
-RUN test -n "$DELTA_VERSION"    || { echo "Error: DELTA_VERSION is empty" >&2; exit 1; } \
- && test -n "$YQ_VERSION"       || { echo "Error: YQ_VERSION is empty" >&2; exit 1; } \
- && test -n "$XH_VERSION"       || { echo "Error: XH_VERSION is empty" >&2; exit 1; } \
- && test -n "$STARSHIP_VERSION" || { echo "Error: STARSHIP_VERSION is empty" >&2; exit 1; } \
- && test -n "$GLOW_VERSION"     || { echo "Error: GLOW_VERSION is empty" >&2; exit 1; } \
- && test -n "$GUM_VERSION"      || { echo "Error: GUM_VERSION is empty" >&2; exit 1; }
+RUN test -n "$DELTA_VERSION"       || { echo "Error: DELTA_VERSION is empty" >&2; exit 1; } \
+ && test -n "$YQ_VERSION"          || { echo "Error: YQ_VERSION is empty" >&2; exit 1; } \
+ && test -n "$XH_VERSION"          || { echo "Error: XH_VERSION is empty" >&2; exit 1; } \
+ && test -n "$STARSHIP_VERSION"    || { echo "Error: STARSHIP_VERSION is empty" >&2; exit 1; } \
+ && test -n "$GLOW_VERSION"        || { echo "Error: GLOW_VERSION is empty" >&2; exit 1; } \
+ && test -n "$GUM_VERSION"         || { echo "Error: GUM_VERSION is empty" >&2; exit 1; } \
+ && test -n "$JUST_VERSION"        || { echo "Error: JUST_VERSION is empty" >&2; exit 1; } \
+ && test -n "$DIFFTASTIC_VERSION"  || { echo "Error: DIFFTASTIC_VERSION is empty" >&2; exit 1; }
 
 # Checksum verification infrastructure
 COPY checksums.txt /tmp/checksums.txt
@@ -87,6 +91,8 @@ RUN . /tmp/sb-init.sh && sb_install xh "$XH_VERSION"
 RUN . /tmp/sb-init.sh && sb_install glow "$GLOW_VERSION"
 RUN . /tmp/sb-init.sh && sb_install gum "$GUM_VERSION"
 RUN . /tmp/sb-init.sh && sb_install starship "$STARSHIP_VERSION"
+RUN . /tmp/sb-init.sh && sb_install just "$JUST_VERSION"
+RUN . /tmp/sb-init.sh && sb_install difftastic "$DIFFTASTIC_VERSION"
 
 # Clean up build-time files
 RUN rm -f /tmp/checksums.txt /tmp/tools.yaml /tmp/tool-lib.sh /tmp/sb-init.sh

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ What's included
 | [bat](https://github.com/sharkdp/bat) | Rust | Cat clone with syntax highlighting |
 | [curl](https://github.com/curl/curl) | C | URL data transfer |
 | [delta](https://github.com/dandavison/delta) | Rust | Syntax-highlighting pager for git diffs |
+| [difftastic](https://github.com/Wilfred/difftastic) | Rust | Syntax-aware structural diff tool (`difft`) |
 | [eza](https://github.com/eza-community/eza) | Rust | Modern ls replacement |
 | [fd](https://github.com/sharkdp/fd) | Rust | Fast, user-friendly find alternative |
 | [fzf](https://github.com/junegunn/fzf) | Go | Fuzzy finder |
@@ -119,6 +120,7 @@ What's included
 | [glow](https://github.com/charmbracelet/glow) | Go | Terminal markdown renderer |
 | [gum](https://github.com/charmbracelet/gum) | Go | Tool for shell scripts and dotfiles |
 | [jq](https://github.com/jqlang/jq) | C | JSON processor |
+| [just](https://github.com/casey/just) | Rust | Command runner / modern make alternative |
 | [nano](https://nano-editor.org) | C | Default text editor |
 | [ripgrep](https://github.com/BurntSushi/ripgrep) | Rust | Fast recursive grep |
 | [starship](https://github.com/starship/starship) | Rust | Cross-shell prompt |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,7 +5,6 @@
 Items are listed in priority order.
 
 - **just** — add [just](https://github.com/casey/just) (modern task runner) to the default image; single binary, zero dependencies, gives users a standard way to define project commands
-- **lazydocker** — add [lazydocker](https://github.com/jesseduffield/lazydocker) (Docker management TUI) to the default image; same author as lazygit, completes the TUI tool suite for developers managing containers
 - **difftastic** — add [difftastic](https://github.com/Wilfred/difftastic) (syntax-aware structural diffs) to the default image; complements delta with language-aware diffing
 - **btop** — add [btop](https://github.com/aristocratos/btop) (system resource monitor TUI) to the default image; fills the "what's eating my CPU/memory" gap without requiring manual package installation
 - **direnv** — add [direnv](https://github.com/direnv/direnv) (automatic per-directory environment loading) to the default image; auto-loads `.envrc` files on `cd`, integrates with zoxide for seamless per-project environment variables

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,8 +4,6 @@
 
 Items are listed in priority order.
 
-- **just** — add [just](https://github.com/casey/just) (modern task runner) to the default image; single binary, zero dependencies, gives users a standard way to define project commands
-- **difftastic** — add [difftastic](https://github.com/Wilfred/difftastic) (syntax-aware structural diffs) to the default image; complements delta with language-aware diffing
 - **direnv** — add [direnv](https://github.com/direnv/direnv) (automatic per-directory environment loading) to the default image; auto-loads `.envrc` files on `cd`, integrates with zoxide for seamless per-project environment variables
 - **Zsh option** — offer Zsh with Oh My Zsh, autosuggestions, and syntax highlighting as a selectable shell in `setup.sh` alongside the Bash default; closes the biggest UX gap vs. competing dev environments
 - **Dotfile portability** — let users mount or bootstrap their own dotfiles (starship.toml, tmux.conf, aliases, etc.) via a `~/.squarebox/` convention, with sensible merge/override behaviour against the defaults
@@ -19,4 +17,6 @@ Items are listed in priority order.
 - **Network firewall / sandboxing mode** — optional network-level isolation (iptables/seccomp) so AI agents can only reach approved endpoints, inspired by trailofbits and clampdown
 - **Multiple concurrent container instances** — support running more than one squarebox container simultaneously
 - **Multi-agent workflow orchestration** — explore adding a layer to run multiple AI coding agents simultaneously in isolated contexts (git worktrees + tmux sessions), inspired by agent-of-empires; may be better to integrate an existing tool than build from scratch
+- ~~**just**~~ — ✅ done: [just](https://github.com/casey/just) pinned in the Dockerfile tier with SHA256 checksums
+- ~~**difftastic**~~ — ✅ done: [difftastic](https://github.com/Wilfred/difftastic) (`difft`) pinned in the Dockerfile tier with SHA256 checksums
 - ~~**Podman compatibility**~~ — ✅ done: install scripts auto-detect Docker or Podman and skip UID chown logic for Podman's rootless user namespace mapping

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,6 @@ Items are listed in priority order.
 
 - **just** — add [just](https://github.com/casey/just) (modern task runner) to the default image; single binary, zero dependencies, gives users a standard way to define project commands
 - **difftastic** — add [difftastic](https://github.com/Wilfred/difftastic) (syntax-aware structural diffs) to the default image; complements delta with language-aware diffing
-- **btop** — add [btop](https://github.com/aristocratos/btop) (system resource monitor TUI) to the default image; fills the "what's eating my CPU/memory" gap without requiring manual package installation
 - **direnv** — add [direnv](https://github.com/direnv/direnv) (automatic per-directory environment loading) to the default image; auto-loads `.envrc` files on `cd`, integrates with zoxide for seamless per-project environment variables
 - **Zsh option** — offer Zsh with Oh My Zsh, autosuggestions, and syntax highlighting as a selectable shell in `setup.sh` alongside the Bash default; closes the biggest UX gap vs. competing dev environments
 - **Dotfile portability** — let users mount or bootstrap their own dotfiles (starship.toml, tmux.conf, aliases, etc.) via a `~/.squarebox/` convention, with sensible merge/override behaviour against the defaults

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,9 +46,9 @@ at each layer:
 |-------|---------------|-----------|-----------------|-----------------|
 | **install.sh** | Git repo from GitHub | HTTPS | Git transport verification | Tracks `main` branch |
 | **Dockerfile APT packages** | Ubuntu 24.04 packages, GitHub CLI, Eza | HTTPS | APT GPG signatures | Distro versions (not pinned) |
-| **Dockerfile binary tools** | 6 tools from GitHub Releases (delta, yq, xh, glow, gum, starship) | HTTPS | SHA256 checksum, build fails on mismatch | Yes, all pinned |
+| **Dockerfile binary tools** | 8 tools from GitHub Releases (delta, yq, xh, glow, gum, starship, just, difftastic) | HTTPS | SHA256 checksum, build fails on mismatch | Yes, all pinned |
 | **setup.sh optional tools** | OpenCode, nvm, Go, editors (micro, edit, fresh, nvim), TUIs (lazygit, gh-dash, yazi), zellij | HTTPS | None beyond transport | No, latest upstream at install time |
-| **sqrbx-update (Dockerfile tier)** | delta, yq, xh, glow, gum, starship | HTTPS | SHA256 checksum fetched from repo, update refused on mismatch or missing checksum | Only vetted versions |
+| **sqrbx-update (Dockerfile tier)** | delta, yq, xh, glow, gum, starship, just, difftastic | HTTPS | SHA256 checksum fetched from repo, update refused on mismatch or missing checksum | Only vetted versions |
 | **sqrbx-update (optional tier)** | Optional tools listed above | HTTPS | None beyond transport | Latest upstream |
 | **setup.sh third-party installers** | Claude Code, uv, .NET | HTTPS | Delegates to vendor installer | No (latest/LTS) |
 

--- a/checksums.txt
+++ b/checksums.txt
@@ -20,3 +20,9 @@ ab12a703cc6efd06caf24860344a2e8bc2518055fdd986f98eb761c47917ef3d  glow_2.1.1_Lin
 # Gum 0.17.0
 69ee169bd6387331928864e94d47ed01ef649fbfe875baed1bbf27b5377a6fdb  gum_0.17.0_Linux_x86_64.tar.gz
 b0b9ed95cbf7c8b7073f17b9591811f5c001e33c7cfd066ca83ce8a07c576f9c  gum_0.17.0_Linux_arm64.tar.gz
+# Just 1.49.0
+05eb2f068b641b06e5b318796c2e27d4dcca608e65b34329a08c1b9f582611bd  just-1.49.0-x86_64-unknown-linux-musl.tar.gz
+993b78f51004248114af22368f69715541542b3c9941c80e02f8ae10eb404ae0  just-1.49.0-aarch64-unknown-linux-musl.tar.gz
+# Difftastic 0.68.0
+f50c2d77f44a551fe24a7abfa955fbb893e6d0ab2a3767f39ca3823f0995dabd  difft-x86_64-unknown-linux-gnu.tar.gz
+faadfb3a88c194033449092fad3a86f1179738a0b3bfc44580c83473bdb17451  difft-aarch64-unknown-linux-gnu.tar.gz

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -52,7 +52,7 @@ run_test_grep() {
 }
 
 # ── Suite: tools ─────────────────────────────────────────────────────────
-# Covers: 5.1-5.12 (tool verification)
+# Covers: 5.1-5.14 (tool verification)
 
 suite_tools() {
 	# 5.1 bat --version + syntax highlighting

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -78,6 +78,12 @@ suite_tools() {
 
 	# 5.10 fzf version
 	run_test "5.10 fzf --version" fzf --version
+
+	# 5.13 just version
+	run_test "5.13 just --version" just --version
+
+	# 5.14 difftastic version (binary is named `difft`)
+	run_test "5.14 difft --version" difft --version
 }
 
 # ── Suite: shell ─────────────────────────────────────────────────────────

--- a/scripts/lib/tools.yaml
+++ b/scripts/lib/tools.yaml
@@ -73,6 +73,26 @@ tools:
     dest: system
     group: dockerfile
 
+  just:
+    repo: casey/just
+    version_prefix: ""
+    artifact: just-{version}-{zarch}-unknown-linux-musl.tar.gz
+    method: tar.gz
+    binaries: just
+    tar_extract: just
+    dest: system
+    group: dockerfile
+
+  difftastic:
+    repo: Wilfred/difftastic
+    version_prefix: ""
+    artifact: difft-{zarch}-unknown-linux-gnu.tar.gz
+    method: tar.gz
+    binaries: difft
+    tar_extract: difft
+    dest: system
+    group: dockerfile
+
   # ── setup.sh tools (installed as user to ~/.local/bin) ──────────────
 
   lazygit:

--- a/scripts/squarebox-update.sh
+++ b/scripts/squarebox-update.sh
@@ -139,6 +139,8 @@ helix_current() { hx --version 2>/dev/null | head -1 | awk '{print $2}' || echo 
 nvim_current() { nvim --version 2>/dev/null | head -1 | awk '{print $2}' | sed 's/^v//' || echo "not installed"; }
 opencode_current() { opencode --version 2>/dev/null | grep -oP '[\d.]+' | head -1 || echo "not installed"; }
 zellij_current() { zellij --version 2>/dev/null | head -1 | awk '{print $2}' || echo "not installed"; }
+just_current() { just --version 2>/dev/null | awk '{print $2}' || echo "not installed"; }
+difftastic_current() { difft --version 2>/dev/null | head -1 | awk '{print $2}' || echo "not installed"; }
 
 # ── Latest version fetching ────────────────────────────────────────────
 # Uses repo from tools.yaml via sb_get; strips v prefix where needed.
@@ -158,8 +160,8 @@ tool_latest() {
 
 # ── Tool registry ──────────────────────────────────────────────────────
 
-TOOLS=(delta yq lazygit xh yazi starship ghdash glow gum micro fresh edit helix nvim opencode zellij)
-TOOL_DISPLAY_NAMES=(delta yq lazygit xh yazi starship gh-dash glow gum micro fresh edit helix nvim opencode zellij)
+TOOLS=(delta yq lazygit xh yazi starship ghdash glow gum just difftastic micro fresh edit helix nvim opencode zellij)
+TOOL_DISPLAY_NAMES=(delta yq lazygit xh yazi starship gh-dash glow gum just difftastic micro fresh edit helix nvim opencode zellij)
 
 # Map display names to tools.yaml names (ghdash → gh-dash)
 yaml_name() {
@@ -183,7 +185,7 @@ usage() {
 	  sqrbx-update --help       Show this help
 
 	${BOLD}Tools:${RESET}
-	  delta, yq, lazygit, xh, yazi, starship, gh-dash, glow, gum, micro, fresh, edit, helix, nvim, opencode, zellij
+	  delta, yq, lazygit, xh, yazi, starship, gh-dash, glow, gum, just, difftastic, micro, fresh, edit, helix, nvim, opencode, zellij
 
 	EOF
 }

--- a/scripts/update-versions.sh
+++ b/scripts/update-versions.sh
@@ -106,6 +106,8 @@ update_arg XH_VERSION "${VERSIONS[xh]}"
 update_arg STARSHIP_VERSION "${VERSIONS[starship]}"
 update_arg GLOW_VERSION "${VERSIONS[glow]}"
 update_arg GUM_VERSION "${VERSIONS[gum]}"
+update_arg JUST_VERSION "${VERSIONS[just]}"
+update_arg DIFFTASTIC_VERSION "${VERSIONS[difftastic]}"
 
 echo
 echo "Done. Review changes with: git diff"


### PR DESCRIPTION
## Summary

- Remove lazydocker from the roadmap — it requires Docker socket access, which conflicts with squarebox's `--cap-drop=ALL` security posture. Mounting the host socket would effectively give the container root on the host, and running a daemon inside the container is too heavy.
- Remove btop from the roadmap (no longer planned).
- Promote `just` and `difftastic` from the roadmap to the default image (Dockerfile tier), with matching entries in `tools.yaml`, `checksums.txt`, and E2E coverage (tests 5.13, 5.14).
- Update the suite tools header range to 5.1–5.14 to match the new tests.

## Test plan

- [x] `build` workflow passes
- [x] E2E tests cover `just --version` and `difft --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)