### PR TITLE
feat: add experimental zsh shell option to setup.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ The `install.sh` script automates initial setup (clone, build, create container,
 5. **TUI tools** — lazygit, gh-dash, yazi (any combination)
 6. **Terminal multiplexers** — tmux, zellij
 7. **SDKs** — Node.js (via nvm), Python (via uv), Go, .NET
+8. **Shell** — bash (default) or zsh + Oh My Zsh + autosuggestions + syntax highlighting (experimental)
 
 Selections are saved to `/workspace/.squarebox/` and reused on subsequent rebuilds.
 
@@ -62,7 +63,7 @@ sqrbx-setup --list            # Show current tool selections
 sqrbx-setup --help            # Show usage
 ```
 
-Valid sections: `git`, `github`, `ai`, `editors`, `tuis`, `multiplexers`, `sdks`.
+Valid sections: `git`, `github`, `ai`, `editors`, `tuis`, `multiplexers`, `sdks`, `shell`.
 
 Run `source ~/.bashrc` after setup to pick up new aliases and PATH changes in the current shell.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -163,6 +163,13 @@ if [ ! -f ~/.squarebox-setup-done ]; then
 		[ -f ~/.squarebox-sdk-paths ] && source ~/.squarebox-sdk-paths
 	fi
 fi
+# Hand off to zsh if the user opted in via setup.sh (experimental).
+# SQUAREBOX_IN_ZSH guards against re-exec loops; SQUAREBOX_NO_ZSH lets
+# users force bash for one shell without removing the marker.
+if [ -f ~/.squarebox-use-zsh ] && [ -z "${SQUAREBOX_IN_ZSH:-}" ] && [ -z "${SQUAREBOX_NO_ZSH:-}" ] && command -v zsh >/dev/null 2>&1; then
+	export SQUAREBOX_IN_ZSH=1
+	exec zsh -l
+fi
 EOFRC
 
 # Display MOTD on interactive shell login

--- a/README.md
+++ b/README.md
@@ -176,6 +176,28 @@ Installed during first-run setup. Choose either, both, or neither:
 | [tmux](https://github.com/tmux/tmux) | Classic terminal multiplexer |
 | [zellij](https://github.com/zellij-org/zellij) | Friendly terminal workspace |
 
+### Shell (Experimental)
+
+By default, squarebox uses Bash. During first-run setup you can opt in to
+**Zsh** instead, which installs:
+
+| Name | Description |
+|------|-------------|
+| [zsh](https://www.zsh.org) | Z shell (via apt) |
+| [Oh My Zsh](https://ohmyz.sh) | Community framework for managing zsh config |
+| [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions) | Fish-like history-based suggestions |
+| [zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting) | Inline command syntax highlighting |
+
+The generated `~/.zshrc` mirrors the default bashrc — same aliases, starship
+prompt, zoxide, and AI/editor/SDK sourcing — layered on top of Oh My Zsh.
+
+> **Experimental:** the marker file `~/.squarebox-use-zsh` causes `~/.bashrc`
+> to `exec zsh -l` on every interactive login, so the next shell start picks
+> up the new shell. Set `SQUAREBOX_NO_ZSH=1` to force bash for a single
+> session, or re-run `sqrbx-setup shell` to switch back permanently. Tooling
+> is primarily tested against bash, so a few edge cases (custom alias files,
+> rebuilds) may need polish — please file an issue if you hit one.
+
 ### SDKs
 
 | SDK | Installed via |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,7 +9,6 @@ Items are listed in priority order.
 - **difftastic** — add [difftastic](https://github.com/Wilfred/difftastic) (syntax-aware structural diffs) to the default image; complements delta with language-aware diffing
 - **btop** — add [btop](https://github.com/aristocratos/btop) (system resource monitor TUI) to the default image; fills the "what's eating my CPU/memory" gap without requiring manual package installation
 - **direnv** — add [direnv](https://github.com/direnv/direnv) (automatic per-directory environment loading) to the default image; auto-loads `.envrc` files on `cd`, integrates with zoxide for seamless per-project environment variables
-- **Zsh option** — offer Zsh with Oh My Zsh, autosuggestions, and syntax highlighting as a selectable shell in `setup.sh` alongside the Bash default; closes the biggest UX gap vs. competing dev environments
 - **Dotfile portability** — let users mount or bootstrap their own dotfiles (starship.toml, tmux.conf, aliases, etc.) via a `~/.squarebox/` convention, with sensible merge/override behaviour against the defaults
 - **MCP server pre-configuration** — ship ready-made MCP server configs (filesystem, GitHub, etc.) as part of the AI assistant setup step
 - **hyperfine** — add [hyperfine](https://github.com/sharkdp/hyperfine) (command-line benchmarking) to the default image
@@ -22,3 +21,4 @@ Items are listed in priority order.
 - **Multiple concurrent container instances** — support running more than one squarebox container simultaneously
 - **Multi-agent workflow orchestration** — explore adding a layer to run multiple AI coding agents simultaneously in isolated contexts (git worktrees + tmux sessions), inspired by agent-of-empires; may be better to integrate an existing tool than build from scratch
 - ~~**Podman compatibility**~~ — ✅ done: install scripts auto-detect Docker or Podman and skip UID chown logic for Podman's rootless user namespace mapping
+- ~~**Zsh option**~~ — ✅ done (experimental): `setup.sh` now offers Zsh with Oh My Zsh, autosuggestions, and syntax highlighting as a selectable shell alongside the Bash default; opt in via the new `shell` setup section

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -166,6 +166,13 @@ suite_setup_editors() {
 	echo "lazygit,gh-dash,yazi" > /workspace/.squarebox/tuis
 	echo "tmux,zellij" > /workspace/.squarebox/multiplexer
 	echo "node,go" > /workspace/.squarebox/sdks
+	# Shell section (experimental): exercise the bash path here. The zsh
+	# install (apt zsh + Oh My Zsh + two plugin clones) is network-heavy and
+	# would significantly slow the CI suite, so it's not pre-seeded by default.
+	echo "bash" > /workspace/.squarebox/shell
+	# Ensure a stale marker from a previous run is cleared so the assertion
+	# below reflects the current selection, not leftover state.
+	rm -f ~/.squarebox-use-zsh
 
 	# Pre-configure git identity
 	git config --global user.name "E2E Test" 2>/dev/null || true
@@ -208,6 +215,18 @@ suite_setup_editors() {
 	run_test "3.11c tuis config saved" test -f /workspace/.squarebox/tuis
 	run_test "3.11d multiplexer config saved" test -f /workspace/.squarebox/multiplexer
 	run_test "3.11e sdks config saved" test -f /workspace/.squarebox/sdks
+	run_test "3.11f shell config saved" test -f /workspace/.squarebox/shell
+
+	# 3.12 shell section: bash selection leaves no zsh handoff marker
+	run_test_grep "3.12a shell config is bash" "bash" cat /workspace/.squarebox/shell
+	TEST_NUM=$((TEST_NUM + 1))
+	if [ ! -e ~/.squarebox-use-zsh ]; then
+		PASS_COUNT=$((PASS_COUNT + 1))
+		echo "ok ${TEST_NUM} - 3.12b no zsh marker for bash selection"
+	else
+		FAIL_COUNT=$((FAIL_COUNT + 1))
+		echo "not ok ${TEST_NUM} - 3.12b no zsh marker for bash selection"
+	fi
 
 	# 4.4 EDITOR set to first selected editor (micro)
 	run_test_grep "4.4 EDITOR set to micro" "micro" cat ~/.squarebox-editor-aliases
@@ -289,6 +308,7 @@ suite_setup_rerun() {
 
 	# --help lists section names
 	run_test_grep "9.3 sqrbx-setup --help lists sections" "editors" sqrbx-setup --help
+	run_test_grep "9.3b sqrbx-setup --help lists shell section" "shell" sqrbx-setup --help
 
 	# --list runs without error
 	run_test "9.4 sqrbx-setup --list runs" sqrbx-setup --list

--- a/scripts/squarebox-setup.sh
+++ b/scripts/squarebox-setup.sh
@@ -16,7 +16,7 @@ GREEN='\033[0;32m'
 CYAN='\033[0;36m'
 RESET='\033[0m'
 
-VALID_SECTIONS=(git github ai editors tuis multiplexers sdks)
+VALID_SECTIONS=(git github ai editors tuis multiplexers sdks shell)
 
 usage() {
 	cat <<-EOF
@@ -36,6 +36,7 @@ usage() {
 	  tuis           TUI tools (lazygit, gh-dash, yazi)
 	  multiplexers   Terminal multiplexers (tmux, zellij)
 	  sdks           SDKs (node, python, go, dotnet)
+	  shell          Default shell (bash, zsh — experimental)
 
 	${BOLD}Examples:${RESET}
 	  sqrbx-setup ai editors       Re-run AI assistant and editor selection
@@ -74,6 +75,7 @@ show_list() {
 		"tuis:TUI tools"
 		"multiplexer:Multiplexers"
 		"sdks:SDKs"
+		"shell:Shell"
 	)
 	for entry in "${configs[@]}"; do
 		local file="${entry%%:*}"

--- a/setup.sh
+++ b/setup.sh
@@ -1351,26 +1351,37 @@ else
 fi
 
 _install_zsh_inner() {
-	sudo apt-get update -qq && sudo apt-get install -y -qq zsh >/dev/null 2>&1
+	sudo apt-get update -qq && sudo apt-get install -y -qq zsh >/dev/null 2>&1 || return 1
+	command -v zsh >/dev/null 2>&1 || return 1
 	# Trust boundary: the Oh My Zsh installer manages its own files via HTTPS.
-	# RUNZSH=no prevents launching a subshell, CHSH=no skips the chsh prompt
-	# (we handle shell switching via the .squarebox-use-zsh marker), and
-	# KEEP_ZSHRC=yes prevents it from writing a .zshrc we'd immediately overwrite.
-	if [ ! -d "$HOME/.oh-my-zsh" ]; then
+	# We resolve the latest release tag at setup time (matching the trust model
+	# used elsewhere in setup.sh for optional tools) instead of tracking master,
+	# so the fetched installer is pinned to a known release rather than a
+	# moving branch. RUNZSH=no prevents launching a subshell, CHSH=no skips the
+	# chsh prompt (we handle shell switching via the .squarebox-use-zsh
+	# marker), and KEEP_ZSHRC=yes prevents it from writing a .zshrc we'd
+	# immediately overwrite.
+	if [ ! -f "$HOME/.oh-my-zsh/oh-my-zsh.sh" ]; then
+		local omz_tag omz_ref
+		omz_tag=$(sb_gh_latest_tag ohmyzsh/ohmyzsh 2>/dev/null || true)
+		omz_ref="${omz_tag:-master}"
 		RUNZSH=no CHSH=no KEEP_ZSHRC=yes \
-			sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended >/dev/null 2>&1
+			sh -c "$(curl -fsSL "https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/${omz_ref}/tools/install.sh")" "" --unattended >/dev/null 2>&1 || return 1
 	fi
+	[ -f "$HOME/.oh-my-zsh/oh-my-zsh.sh" ] || return 1
 	local custom="$HOME/.oh-my-zsh/custom"
 	if [ ! -d "$custom/plugins/zsh-autosuggestions" ]; then
 		git clone --depth=1 https://github.com/zsh-users/zsh-autosuggestions \
-			"$custom/plugins/zsh-autosuggestions" >/dev/null 2>&1
+			"$custom/plugins/zsh-autosuggestions" >/dev/null 2>&1 || return 1
 	fi
 	if [ ! -d "$custom/plugins/zsh-syntax-highlighting" ]; then
 		git clone --depth=1 https://github.com/zsh-users/zsh-syntax-highlighting \
-			"$custom/plugins/zsh-syntax-highlighting" >/dev/null 2>&1
+			"$custom/plugins/zsh-syntax-highlighting" >/dev/null 2>&1 || return 1
 	fi
+	[ -d "$custom/plugins/zsh-autosuggestions" ] || return 1
+	[ -d "$custom/plugins/zsh-syntax-highlighting" ] || return 1
 	# Generate ~/.zshrc that mirrors ~/.bashrc, layered on Oh My Zsh.
-	cat > "$HOME/.zshrc" <<-'ZSHRC'
+	cat > "$HOME/.zshrc" <<-'ZSHRC' || return 1
 		# squarebox zsh config (experimental) — mirrors ~/.bashrc
 		export ZSH="$HOME/.oh-my-zsh"
 		ZSH_THEME=""
@@ -1402,13 +1413,13 @@ _install_zsh_inner() {
 		export PATH="$HOME/.local/bin:$PATH"
 		[ -x ~/motd.sh ] && ~/motd.sh
 	ZSHRC
+	[ -f "$HOME/.zshrc" ] || return 1
 }
 
 install_zsh() {
-	if command -v zsh &>/dev/null && [ -d "$HOME/.oh-my-zsh" ] && [ -f "$HOME/.zshrc" ]; then
-		echo "Zsh already configured, skipping."
-		return 0
-	fi
+	# Always invoke the inner installer: each step is idempotent (guards with
+	# `-d` / `-f` before apt/curl/clone), and running it every time ensures any
+	# missing plugins from a previous partial install get re-cloned.
 	run_with_spinner "Installing Zsh + Oh My Zsh..." _install_zsh_inner
 }
 
@@ -1416,7 +1427,7 @@ case "$shell_choice" in
 	zsh)
 		if install_zsh; then
 			touch ~/.squarebox-use-zsh
-			echo "Zsh will be used on the next shell start."
+			echo "Zsh will take over at the end of this setup (next interactive shell)."
 		else
 			echo "Warning: Zsh installation failed; staying on bash."
 			rm -f ~/.squarebox-use-zsh

--- a/setup.sh
+++ b/setup.sh
@@ -17,7 +17,7 @@ done
 
 # If --rerun with no specific sections, run all sections
 if $SB_RERUN && [ ${#SB_SECTIONS[@]} -eq 0 ]; then
-	SB_SECTIONS=(git github ai editors tuis multiplexers sdks)
+	SB_SECTIONS=(git github ai editors tuis multiplexers sdks shell)
 fi
 
 should_run() {
@@ -1292,6 +1292,141 @@ for sdk in $(echo "$sdk_list" | tr ',' ' '); do
 	esac
 done
 fi # should_run sdks
+
+# Shell (experimental) — offer Zsh + Oh My Zsh as an alternative to Bash
+if should_run shell; then
+SHELL_CONFIG="/workspace/.squarebox/shell"
+
+shell_prev=""
+if [ -f "$SHELL_CONFIG" ]; then
+	shell_prev=$(cat "$SHELL_CONFIG")
+fi
+
+if $INTERACTIVE; then
+	echo
+	section_header "Shell (experimental)"
+	if $HAS_GUM; then
+		gum_selected=""
+		case "$shell_prev" in
+			zsh) gum_selected="zsh (experimental)" ;;
+			bash) gum_selected="bash" ;;
+		esac
+		gum_args=(--header "Select default shell:")
+		[ -n "$gum_selected" ] && gum_args+=(--selected "$gum_selected")
+		shell_pick=$(gum choose "${gum_args[@]}" "bash" "zsh (experimental)") || shell_pick=""
+		case "$shell_pick" in
+			"zsh (experimental)") shell_choice="zsh" ;;
+			"bash")               shell_choice="bash" ;;
+			*)                    shell_choice="$shell_prev" ;;
+		esac
+	else
+		echo "Select default shell:"
+		for sh_item in "1:bash:GNU Bash (default)" "2:zsh:Zsh + Oh My Zsh + autosuggestions + syntax highlighting (experimental)"; do
+			num="${sh_item%%:*}"; rest="${sh_item#*:}"; key="${rest%%:*}"; desc="${rest#*:}"
+			if [ "$key" = "$shell_prev" ]; then
+				echo "  ${num}) ${key} — ${desc} [current]"
+			else
+				echo "  ${num}) ${key} — ${desc}"
+			fi
+		done
+		read -rp "Selection [1,2/skip]: " shell_selection
+		if [ -z "$shell_selection" ] && [ -n "$shell_prev" ]; then
+			shell_choice="$shell_prev"
+		else
+			case "$shell_selection" in
+				1) shell_choice="bash" ;;
+				2) shell_choice="zsh" ;;
+				*) shell_choice="${shell_prev:-bash}" ;;
+			esac
+		fi
+	fi
+	[ -z "$shell_choice" ] && shell_choice="bash"
+	echo "$shell_choice" > "$SHELL_CONFIG"
+elif [ -n "$shell_prev" ]; then
+	shell_choice="$shell_prev"
+	[ "$shell_choice" = "zsh" ] && echo "Configuring shell: zsh (from previous selection)"
+else
+	shell_choice="bash"
+	echo "$shell_choice" > "$SHELL_CONFIG"
+fi
+
+_install_zsh_inner() {
+	sudo apt-get update -qq && sudo apt-get install -y -qq zsh >/dev/null 2>&1
+	# Trust boundary: the Oh My Zsh installer manages its own files via HTTPS.
+	# RUNZSH=no prevents launching a subshell, CHSH=no skips the chsh prompt
+	# (we handle shell switching via the .squarebox-use-zsh marker), and
+	# KEEP_ZSHRC=yes prevents it from writing a .zshrc we'd immediately overwrite.
+	if [ ! -d "$HOME/.oh-my-zsh" ]; then
+		RUNZSH=no CHSH=no KEEP_ZSHRC=yes \
+			sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended >/dev/null 2>&1
+	fi
+	local custom="$HOME/.oh-my-zsh/custom"
+	if [ ! -d "$custom/plugins/zsh-autosuggestions" ]; then
+		git clone --depth=1 https://github.com/zsh-users/zsh-autosuggestions \
+			"$custom/plugins/zsh-autosuggestions" >/dev/null 2>&1
+	fi
+	if [ ! -d "$custom/plugins/zsh-syntax-highlighting" ]; then
+		git clone --depth=1 https://github.com/zsh-users/zsh-syntax-highlighting \
+			"$custom/plugins/zsh-syntax-highlighting" >/dev/null 2>&1
+	fi
+	# Generate ~/.zshrc that mirrors ~/.bashrc, layered on Oh My Zsh.
+	cat > "$HOME/.zshrc" <<-'ZSHRC'
+		# squarebox zsh config (experimental) — mirrors ~/.bashrc
+		export ZSH="$HOME/.oh-my-zsh"
+		ZSH_THEME=""
+		plugins=(git zsh-autosuggestions zsh-syntax-highlighting)
+		[ -f "$ZSH/oh-my-zsh.sh" ] && source "$ZSH/oh-my-zsh.sh"
+
+		eval "$(starship init zsh)"
+		eval "$(zoxide init zsh --cmd cd)"
+		alias ls='eza --icons'
+		alias ll='eza -la --icons'
+		alias lsa='ls -a'
+		alias lt='eza --tree --level=2 --long --icons --git'
+		alias lta='lt -a'
+		alias cat='bat --paging=never'
+		alias ff="fzf --preview 'bat --style=numbers --color=always {}'"
+		alias eff='$EDITOR "$(ff)"'
+		alias ..='cd ..'
+		alias ...='cd ../..'
+		alias ....='cd ../../..'
+		export EDITOR='nano'
+		[ -f ~/.squarebox-ai-aliases ] && source ~/.squarebox-ai-aliases
+		[ -f ~/.squarebox-editor-aliases ] && source ~/.squarebox-editor-aliases
+		[ -f ~/.squarebox-tui-aliases ] && source ~/.squarebox-tui-aliases
+		[ -f ~/.squarebox-sdk-paths ] && source ~/.squarebox-sdk-paths
+		alias g='git'
+		alias gcm='git commit -m'
+		alias gcam='git commit -a -m'
+		alias gcad='git commit -a --amend'
+		export PATH="$HOME/.local/bin:$PATH"
+		[ -x ~/motd.sh ] && ~/motd.sh
+	ZSHRC
+}
+
+install_zsh() {
+	if command -v zsh &>/dev/null && [ -d "$HOME/.oh-my-zsh" ] && [ -f "$HOME/.zshrc" ]; then
+		echo "Zsh already configured, skipping."
+		return 0
+	fi
+	run_with_spinner "Installing Zsh + Oh My Zsh..." _install_zsh_inner
+}
+
+case "$shell_choice" in
+	zsh)
+		if install_zsh; then
+			touch ~/.squarebox-use-zsh
+			echo "Zsh will be used on the next shell start."
+		else
+			echo "Warning: Zsh installation failed; staying on bash."
+			rm -f ~/.squarebox-use-zsh
+		fi
+		;;
+	bash|*)
+		rm -f ~/.squarebox-use-zsh
+		;;
+esac
+fi # should_run shell
 
 echo
 


### PR DESCRIPTION
Closes the biggest UX gap vs. competing dev environments by offering
Zsh + Oh My Zsh + zsh-autosuggestions + zsh-syntax-highlighting as a
selectable shell during first-run setup, alongside the Bash default.

The new `shell` section installs zsh via apt, runs the Oh My Zsh
unattended installer (RUNZSH=no/CHSH=no/KEEP_ZSHRC=yes), clones the
two plugin repos, and writes a `~/.zshrc` that mirrors the default
bashrc — same aliases, starship, zoxide, and AI/editor/SDK sourcing.

A `~/.squarebox-use-zsh` marker tells `~/.bashrc` to `exec zsh -l` on
the next interactive login. SQUAREBOX_NO_ZSH=1 forces bash for one
session; re-run `sqrbx-setup shell` to switch back permanently.