### PR TITLE
fix: reset stale running container on sqrbx resume

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -204,7 +204,7 @@ function sqrbx {
     # Reset so the next start attaches to a fresh PID1 that paints a visible prompt.
     $running = (docker inspect -f '{{.State.Running}}' squarebox 2>$null)
     if ($running -and $running.Trim() -eq 'true') {
-        docker stop squarebox | Out-Null
+        docker stop squarebox > $null 2>&1
     }
     docker start -ai squarebox
 }

--- a/install.ps1
+++ b/install.ps1
@@ -197,8 +197,18 @@ $profileBlock = @'
 # >>> squarebox >>>
 # squarebox shell integration - managed by install.ps1.
 Remove-Item Alias:sqrbx, Alias:squarebox, Alias:sqrbx-rebuild, Alias:squarebox-rebuild -ErrorAction SilentlyContinue
-function sqrbx { docker start -ai squarebox }
-function squarebox { docker start -ai squarebox }
+function sqrbx {
+    # If the container was left running after an ungraceful exit (closed
+    # terminal instead of 'exit'), attaching to PID1 bash drops you onto a
+    # prompt it already printed to the dead TTY - blinking cursor, no output.
+    # Reset so the next start attaches to a fresh PID1 that paints a visible prompt.
+    $running = (docker inspect -f '{{.State.Running}}' squarebox 2>$null)
+    if ($running -and $running.Trim() -eq 'true') {
+        docker stop squarebox | Out-Null
+    }
+    docker start -ai squarebox
+}
+function squarebox { sqrbx @args }
 function sqrbx-rebuild { & "__INSTALL_DIR__\install.ps1" @args }
 function squarebox-rebuild { sqrbx-rebuild @args }
 # <<< squarebox <<<

--- a/install.sh
+++ b/install.sh
@@ -167,7 +167,21 @@ cat > "$SQRBX_INIT" <<SQRBXEOF
 # Managed by squarebox install.sh — overwritten on every install.
 # Drop any stale aliases with these names so they don't shadow the functions.
 unalias sqrbx squarebox sqrbx-rebuild squarebox-rebuild 2>/dev/null || true
-sqrbx() { if command -v winpty &>/dev/null && [[ -n "\${MSYSTEM:-}" ]]; then winpty docker start -ai squarebox; else docker start -ai squarebox; fi; }
+sqrbx() {
+	# If the container was left running after an ungraceful exit (closed
+	# terminal instead of \`exit\`), attaching to PID1 bash drops you onto a
+	# prompt it already printed to the dead TTY — blinking cursor, no
+	# output. Reset so the next start attaches to a fresh PID1 that paints
+	# a visible prompt.
+	if [ "\$(docker inspect -f '{{.State.Running}}' squarebox 2>/dev/null)" = "true" ]; then
+		docker stop squarebox >/dev/null 2>&1 || true
+	fi
+	if command -v winpty &>/dev/null && [[ -n "\${MSYSTEM:-}" ]]; then
+		winpty docker start -ai squarebox
+	else
+		docker start -ai squarebox
+	fi
+}
 squarebox() { sqrbx "\$@"; }
 sqrbx-rebuild() { "${INSTALL_DIR}/install.sh" "\$@"; }
 squarebox-rebuild() { sqrbx-rebuild "\$@"; }


### PR DESCRIPTION
## Summary
- When a squarebox terminal is closed without typing `exit`, PID1 bash can stay alive in the container. The next `sqrbx` call then attaches to a shell that already printed its prompt to the dead TTY, appearing as a blinking cursor with no output.
- `sqrbx` now stops the container first if it's running, so `docker start -ai` always attaches to a fresh PID1 bash that paints a visible prompt. Same fix mirrored in `install.ps1` for Windows users.
- Preserves the documented "suspends on exit" lifecycle — `exit` still stops the container normally; no lifecycle drift like a `docker exec` approach would cause.

## Test plan
- [ ] Fresh install → `sqrbx` → `exit` → `sqrbx` (normal flow still works)
- [ ] `sqrbx` → close terminal window ungracefully → `sqrbx` (prompt repaints cleanly instead of blinking cursor)
- [ ] Windows pwsh: `install.ps1` → same ungraceful-close flow via `sqrbx`
- [ ] Git Bash on Windows: winpty branch still wraps the start command

🤖 Generated with [Claude Code](https://claude.com/claude-code)