### PR TITLE
feat: add Rust as an SDK option

### DIFF
--- a/.claude/commands/regenerate-demo.md
+++ b/.claude/commands/regenerate-demo.md
@@ -18,7 +18,7 @@ If VHS is not installed, install it before proceeding. On macOS: `brew install v
    - GitHub CLI auth
    - AI coding assistant selection (Claude Code, OpenCode, Both)
    - Text editor selection (micro, edit, fresh, helix, nvim)
-   - SDK selection (Node.js, Python, Go, .NET)
+   - SDK selection (Node.js, Python, Go, .NET, Rust)
 
 3. If the user wants to change the recording settings (dimensions, theme, timing), update `demo/demo.tape`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ The `install.sh` script automates initial setup (clone, build, create container,
 4. **Text editors** — micro, edit (Microsoft), fresh, nvim (nano is always available)
 5. **TUI tools** — lazygit, gh-dash, yazi (any combination)
 6. **Terminal multiplexers** — tmux, zellij
-7. **SDKs** — Node.js (via nvm), Python (via uv), Go, .NET
+7. **SDKs** — Node.js (via nvm), Python (via uv), Go, .NET, Rust (via rustup)
 8. **Shell** — bash (default) or zsh + Oh My Zsh + autosuggestions + syntax highlighting (experimental)
 
 Selections are saved to `/workspace/.squarebox/` and reused on subsequent rebuilds.

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ prompt, zoxide, and AI/editor/SDK sourcing — layered on top of Oh My Zsh.
 | Python | [uv](https://github.com/astral-sh/uv) |
 | Go | [go.dev](https://go.dev) |
 | .NET | [dotnet-install](https://dot.net) |
+| Rust | [rustup](https://rustup.rs) |
 
 Aliases
 -------

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,7 +50,7 @@ at each layer:
 | **setup.sh optional tools** | OpenCode, nvm, Go, editors (micro, edit, fresh, nvim), TUIs (lazygit, gh-dash, yazi), zellij | HTTPS | None beyond transport | No, latest upstream at install time |
 | **sqrbx-update (Dockerfile tier)** | delta, yq, xh, glow, gum, starship | HTTPS | SHA256 checksum fetched from repo, update refused on mismatch or missing checksum | Only vetted versions |
 | **sqrbx-update (optional tier)** | Optional tools listed above | HTTPS | None beyond transport | Latest upstream |
-| **setup.sh third-party installers** | Claude Code, uv, .NET | HTTPS | Delegates to vendor installer | No (latest/LTS) |
+| **setup.sh third-party installers** | Claude Code, uv, .NET, rustup | HTTPS | Delegates to vendor installer | No (latest/LTS) |
 
 **What this means in practice:**
 
@@ -63,8 +63,8 @@ at each layer:
   tool's installer yourself. You get new features without waiting for a
   squarebox release, at the cost of the build-time pinning guarantee.
 - Third-party install scripts (Claude Code from Anthropic, uv from Astral, .NET
-  from Microsoft) delegate to the vendor installer and inherit whatever
-  verification that installer performs.
+  from Microsoft, rustup from the Rust project) delegate to the vendor installer
+  and inherit whatever verification that installer performs.
 - APT packages are verified by Ubuntu's and each repo's GPG signatures.
 
 ## Container isolation

--- a/demo/setup-demo.sh
+++ b/demo/setup-demo.sh
@@ -95,7 +95,7 @@ echo
 section_header "SDKs"
 selected=$(gum choose --no-limit \
     --header "Select SDKs to install:" \
-    "Node.js" "Python" "Go" ".NET") || true
+    "Node.js" "Python" "Go" ".NET" "Rust") || true
 
 while IFS= read -r line; do
     [ -z "$line" ] && continue
@@ -111,6 +111,7 @@ while IFS= read -r line; do
         "Python") run_with_spinner "Installing Python (via uv)..." 0.8 ;;
         "Go")     run_with_spinner "Installing Go go1.26.1..." 0.8 ;;
         ".NET")   run_with_spinner "Installing .NET..." 0.8 ;;
+        "Rust")   run_with_spinner "Installing Rust (via rustup)..." 0.8 ;;
     esac
 done <<< "$selected"
 

--- a/motd.sh
+++ b/motd.sh
@@ -17,6 +17,7 @@ if [ -f "$sdk_config" ]; then
 			python) ver=$(python3 --version 2>/dev/null | awk '{print $2}'); [ -z "$ver" ] && ver=$(uv --version 2>/dev/null | awk '{print $2}') && ver="uv $ver"; [ -n "$ver" ] && sdks+=("Python $ver") ;;
 			go)     ver=$(go version 2>/dev/null | awk '{print $3}' | tr -d 'go') && [ -n "$ver" ] && sdks+=("Go $ver") ;;
 			dotnet) ver=$(DOTNET_NOLOGO=1 dotnet --version 2>/dev/null | tail -1) && [ -n "$ver" ] && sdks+=(".NET $ver") ;;
+			rust)   ver=$(rustc --version 2>/dev/null | awk '{print $2}') && [ -n "$ver" ] && sdks+=("Rust $ver") ;;
 		esac
 	done
 fi

--- a/scripts/squarebox-setup.sh
+++ b/scripts/squarebox-setup.sh
@@ -35,7 +35,7 @@ usage() {
 	  editors        Text editors (micro, edit, fresh, nvim)
 	  tuis           TUI tools (lazygit, gh-dash, yazi)
 	  multiplexers   Terminal multiplexers (tmux, zellij)
-	  sdks           SDKs (node, python, go, dotnet)
+	  sdks           SDKs (node, python, go, dotnet, rust)
 	  shell          Default shell (bash, zsh — experimental)
 
 	${BOLD}Examples:${RESET}

--- a/setup.sh
+++ b/setup.sh
@@ -1152,12 +1152,13 @@ if $INTERACTIVE; then
 				python) gum_selected="${gum_selected:+$gum_selected,}Python" ;;
 				go)     gum_selected="${gum_selected:+$gum_selected,}Go" ;;
 				dotnet) gum_selected="${gum_selected:+$gum_selected,}.NET" ;;
+				rust)   gum_selected="${gum_selected:+$gum_selected,}Rust" ;;
 			esac
 		done
 		gum_args=(--no-limit --header "Select SDKs to install:")
 		[ -n "$gum_selected" ] && gum_args+=(--selected "$gum_selected")
 		selected=$(gum choose "${gum_args[@]}" \
-			"Node.js" "Python" "Go" ".NET") || true
+			"Node.js" "Python" "Go" ".NET" "Rust") || true
 		sdk_list=""
 		while IFS= read -r line; do
 			case "$line" in
@@ -1165,13 +1166,14 @@ if $INTERACTIVE; then
 				"Python")  sdk_list="${sdk_list:+$sdk_list,}python" ;;
 				"Go")      sdk_list="${sdk_list:+$sdk_list,}go" ;;
 				".NET")    sdk_list="${sdk_list:+$sdk_list,}dotnet" ;;
+				"Rust")    sdk_list="${sdk_list:+$sdk_list,}rust" ;;
 			esac
 		done <<< "$selected"
 		# Empty gum output means nothing selected
 		[ -z "$selected" ] && sdk_list=""
 	else
 		echo "Select SDKs to install (comma-separated, 'all', or 'none' to skip):"
-		for sdk_item in "1:node:Node.js" "2:python:Python" "3:go:Go" "4:dotnet:.NET"; do
+		for sdk_item in "1:node:Node.js" "2:python:Python" "3:go:Go" "4:dotnet:.NET" "5:rust:Rust"; do
 			num="${sdk_item%%:*}"; rest="${sdk_item#*:}"; key="${rest%%:*}"; label="${rest#*:}"
 			if [[ ",$sdk_prev," == *",${key},"* ]]; then
 				echo "  ${num}) ${label} [installed]"
@@ -1179,13 +1181,13 @@ if $INTERACTIVE; then
 				echo "  ${num}) ${label}"
 			fi
 		done
-		read -rp "Selection [1,2,3,4/all/none]: " sdk_selection
+		read -rp "Selection [1,2,3,4,5/all/none]: " sdk_selection
 		if [ -z "$sdk_selection" ] && [ -n "$sdk_prev" ]; then
 			sdk_list="$sdk_prev"
 		else
 			sdk_list=""
 			if [ "$sdk_selection" = "all" ]; then
-				sdk_list="node,python,go,dotnet"
+				sdk_list="node,python,go,dotnet,rust"
 			elif [ "$sdk_selection" != "none" ] && [ -n "$sdk_selection" ]; then
 				for item in $(echo "$sdk_selection" | tr ',' ' '); do
 					case "$item" in
@@ -1193,6 +1195,7 @@ if $INTERACTIVE; then
 						2) sdk_list="${sdk_list:+$sdk_list,}python" ;;
 						3) sdk_list="${sdk_list:+$sdk_list,}go" ;;
 						4) sdk_list="${sdk_list:+$sdk_list,}dotnet" ;;
+						5) sdk_list="${sdk_list:+$sdk_list,}rust" ;;
 					esac
 				done
 			fi
@@ -1283,12 +1286,35 @@ install_dotnet() {
 	fi
 }
 
+_install_rust_inner() {
+	# Trust boundary: the rustup install script manages its own binary
+	# fetching and verification. We rely on HTTPS for script integrity.
+	# --no-modify-path: squarebox manages PATH via ~/.squarebox-sdk-paths.
+	curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs \
+		| sh -s -- -y --default-toolchain stable --no-modify-path &>/dev/null
+	if ! grep -q '\.cargo/bin' ~/.squarebox-sdk-paths 2>/dev/null; then
+		cat <<'PATHS' >> ~/.squarebox-sdk-paths
+export PATH="$HOME/.cargo/bin:$PATH"
+PATHS
+	fi
+}
+
+install_rust() {
+	if [ -x "${HOME}/.cargo/bin/rustc" ]; then echo "Rust already installed, skipping."; return 0; fi
+	run_with_spinner "Installing Rust (via rustup)..." _install_rust_inner
+	if [ ! -x "${HOME}/.cargo/bin/rustc" ]; then
+		echo "Error: rustc binary not found after installation" >&2
+		return 1
+	fi
+}
+
 for sdk in $(echo "$sdk_list" | tr ',' ' '); do
 	case "$sdk" in
 		node) install_node || echo "Warning: Node.js installation failed." ;;
 		python) install_python || echo "Warning: Python (uv) installation failed." ;;
 		go) install_go || echo "Warning: Go installation failed." ;;
 		dotnet) install_dotnet || echo "Warning: .NET installation failed." ;;
+		rust) install_rust || echo "Warning: Rust installation failed." ;;
 	esac
 done
 fi # should_run sdks


### PR DESCRIPTION
## Summary
- Adds Rust to the SDK picker in `setup.sh` via rustup (default toolchain: stable; `--no-modify-path` so squarebox owns PATH)
- Follows the existing Python/Go/.NET pattern: install inline, PATH appended to `~/.squarebox-sdk-paths`, binary verified at `$HOME/.cargo/bin/rustc`
- Updates MOTD version readout, demo source script, and every docs/help enumeration of the SDK list

## Test plan
- [ ] Rebuild image, first-run setup shows **Rust** as a fifth option in the gum picker and numbered menu
- [ ] Selecting Rust installs rustup; `rustc`, `cargo`, `rustfmt`, and `cargo clippy` all run after `source ~/.squarebox-sdk-paths`
- [ ] Selection persists at `/workspace/.squarebox/sdks` and survives `docker start -ai`
- [ ] `sqrbx-setup --list` shows `rust` in the SDKs line; `sqrbx-setup sdks` re-prompts with Rust pre-selected
- [ ] MOTD shows `Rust <ver>` on login when installed
- [ ] Non-interactive `all` expands to `node,python,go,dotnet,rust`

## Notes
- The demo gif (`demo/squarebox-setup.gif`) still needs re-recording via `vhs demo/demo.tape` on the `demo` branch — the source script is updated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)