### PR TITLE
docs: mark Podman support as experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 multiple platforms and devices.*
 
 **squarebox** packages a complete terminal-based development environment
-into a single container (Docker or Podman): modern CLI tools, AI coding
+into a single container (Docker; Podman experimental): modern CLI tools, AI coding
 assistants, language SDKs, and an opinionated set of shell aliases. Run the
 same box anywhere (desktop, VPS, or Codespace) and SSH in from your laptop,
 tablet, or phone (please don't).
@@ -27,10 +27,9 @@ The installer auto-detects which runtime is available. If both are installed, it
 asks which to use. Override with `SQUAREBOX_RUNTIME=docker` or
 `SQUAREBOX_RUNTIME=podman`.
 
-> **Podman (Experimental):** Podman support is experimental. Docker is the
-> primary tested runtime; Podman works but may have rough edges around volume
-> mounts, SSH agent forwarding, or rebuild flows — please file an issue if you
-> hit one.
+> **Podman (Experimental):** Docker is the primary tested runtime; Podman may
+> have rough edges around volume mounts, SSH agent forwarding, or rebuild
+> flows — please file an issue if you hit one.
 
 ### Don't have Docker or Podman? One-line install
 

--- a/README.md
+++ b/README.md
@@ -20,12 +20,17 @@ install, interactive first-run setup, sensible defaults (thanks [omarchy](https:
 Prerequisites
 -------------
 
-- [Docker](https://docs.docker.com/get-docker/) or [Podman](https://podman.io/getting-started/installation) (see one-line install below if you don't have either)
+- [Docker](https://docs.docker.com/get-docker/) or [Podman](https://podman.io/getting-started/installation) (experimental — see one-line install below if you don't have either)
 - [Git](https://git-scm.com/) - on Windows, install [Git for Windows](https://gitforwindows.org/)
 
 The installer auto-detects which runtime is available. If both are installed, it
 asks which to use. Override with `SQUAREBOX_RUNTIME=docker` or
 `SQUAREBOX_RUNTIME=podman`.
+
+> **Podman (Experimental):** Podman support is experimental. Docker is the
+> primary tested runtime; Podman works but may have rough edges around volume
+> mounts, SSH agent forwarding, or rebuild flows — please file an issue if you
+> hit one.
 
 ### Don't have Docker or Podman? One-line install
 


### PR DESCRIPTION
## Summary
- Adds an "(experimental)" note to the Podman reference in the Prerequisites list
- Adds a callout block clarifying that Docker is the primary tested runtime and that Podman may have rough edges around volume mounts, SSH agent forwarding, or rebuild flows

## Test plan
- [ ] Render the README on GitHub and verify the callout block displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)