### PR TITLE
feat: add experimental fish shell option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -170,6 +170,13 @@ if [ -f ~/.squarebox-use-zsh ] && [ -z "${SQUAREBOX_IN_ZSH:-}" ] && [ -z "${SQUA
 	export SQUAREBOX_IN_ZSH=1
 	exec zsh -l
 fi
+# Hand off to fish if the user opted in via setup.sh (experimental).
+# SQUAREBOX_IN_FISH guards against re-exec loops; SQUAREBOX_NO_FISH lets
+# users force bash for one shell without removing the marker.
+if [ -f ~/.squarebox-use-fish ] && [ -z "${SQUAREBOX_IN_FISH:-}" ] && [ -z "${SQUAREBOX_NO_FISH:-}" ] && command -v fish >/dev/null 2>&1; then
+	export SQUAREBOX_IN_FISH=1
+	exec fish -l
+fi
 EOFRC
 
 # Display MOTD on interactive shell login

--- a/README.md
+++ b/README.md
@@ -179,7 +179,9 @@ Installed during first-run setup. Choose either, both, or neither:
 ### Shell (Experimental)
 
 By default, squarebox uses Bash. During first-run setup you can opt in to
-**Zsh** instead, which installs:
+**Zsh** or **Fish** instead.
+
+**Zsh** installs:
 
 | Name | Description |
 |------|-------------|
@@ -191,12 +193,21 @@ By default, squarebox uses Bash. During first-run setup you can opt in to
 The generated `~/.zshrc` mirrors the default bashrc — same aliases, starship
 prompt, zoxide, and AI/editor/SDK sourcing — layered on top of Oh My Zsh.
 
-> **Experimental:** the marker file `~/.squarebox-use-zsh` causes `~/.bashrc`
-> to `exec zsh -l` on every interactive login, so the next shell start picks
-> up the new shell. Set `SQUAREBOX_NO_ZSH=1` to force bash for a single
+**Fish** installs [fish](https://fishshell.com) (via apt), which ships with
+autosuggestions and syntax highlighting built in. The generated
+`~/.config/fish/config.fish` mirrors the default bashrc in fish-native syntax;
+AI/editor/TUI/SDK selections are translated from their bash files into
+`~/.config/fish/conf.d/squarebox-selections.fish` at setup time.
+
+> **Experimental:** the marker file `~/.squarebox-use-zsh` (or
+> `~/.squarebox-use-fish`) causes `~/.bashrc` to `exec` the chosen shell on
+> every interactive login, so the next shell start picks up the new shell.
+> Set `SQUAREBOX_NO_ZSH=1` or `SQUAREBOX_NO_FISH=1` to force bash for a single
 > session, or re-run `sqrbx-setup shell` to switch back permanently. Tooling
-> is primarily tested against bash, so a few edge cases (custom alias files,
-> rebuilds) may need polish — please file an issue if you hit one.
+> is primarily tested against bash, so a few edge cases may need polish —
+> please file an issue if you hit one. Known fish limitation: nvm (Node.js)
+> is not wired into fish; install [nvm.fish](https://github.com/jorgebucaran/nvm.fish)
+> separately if you need it.
 
 ### SDKs
 

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -170,9 +170,9 @@ suite_setup_editors() {
 	# install (apt zsh + Oh My Zsh + two plugin clones) is network-heavy and
 	# would significantly slow the CI suite, so it's not pre-seeded by default.
 	echo "bash" > /workspace/.squarebox/shell
-	# Ensure a stale marker from a previous run is cleared so the assertion
+	# Ensure stale markers from a previous run are cleared so the assertion
 	# below reflects the current selection, not leftover state.
-	rm -f ~/.squarebox-use-zsh
+	rm -f ~/.squarebox-use-zsh ~/.squarebox-use-fish
 
 	# Pre-configure git identity
 	git config --global user.name "E2E Test" 2>/dev/null || true

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -217,7 +217,7 @@ suite_setup_editors() {
 	run_test "3.11e sdks config saved" test -f /workspace/.squarebox/sdks
 	run_test "3.11f shell config saved" test -f /workspace/.squarebox/shell
 
-	# 3.12 shell section: bash selection leaves no zsh handoff marker
+	# 3.12 shell section: bash selection leaves no zsh/fish handoff markers
 	run_test_grep "3.12a shell config is bash" "bash" cat /workspace/.squarebox/shell
 	TEST_NUM=$((TEST_NUM + 1))
 	if [ ! -e ~/.squarebox-use-zsh ]; then
@@ -226,6 +226,14 @@ suite_setup_editors() {
 	else
 		FAIL_COUNT=$((FAIL_COUNT + 1))
 		echo "not ok ${TEST_NUM} - 3.12b no zsh marker for bash selection"
+	fi
+	TEST_NUM=$((TEST_NUM + 1))
+	if [ ! -e ~/.squarebox-use-fish ]; then
+		PASS_COUNT=$((PASS_COUNT + 1))
+		echo "ok ${TEST_NUM} - 3.12c no fish marker for bash selection"
+	else
+		FAIL_COUNT=$((FAIL_COUNT + 1))
+		echo "not ok ${TEST_NUM} - 3.12c no fish marker for bash selection"
 	fi
 
 	# 4.4 EDITOR set to first selected editor (micro)

--- a/scripts/squarebox-setup.sh
+++ b/scripts/squarebox-setup.sh
@@ -36,7 +36,7 @@ usage() {
 	  tuis           TUI tools (lazygit, gh-dash, yazi)
 	  multiplexers   Terminal multiplexers (tmux, zellij)
 	  sdks           SDKs (node, python, go, dotnet)
-	  shell          Default shell (bash, zsh — experimental)
+	  shell          Default shell (bash, zsh/fish — experimental)
 
 	${BOLD}Examples:${RESET}
 	  sqrbx-setup ai editors       Re-run AI assistant and editor selection

--- a/setup.sh
+++ b/setup.sh
@@ -1293,7 +1293,7 @@ for sdk in $(echo "$sdk_list" | tr ',' ' '); do
 done
 fi # should_run sdks
 
-# Shell (experimental) — offer Zsh + Oh My Zsh as an alternative to Bash
+# Shell (experimental) — offer Zsh + Oh My Zsh or Fish as alternatives to Bash
 if should_run shell; then
 SHELL_CONFIG="/workspace/.squarebox/shell"
 
@@ -1304,24 +1304,29 @@ fi
 
 if $INTERACTIVE; then
 	echo
-	section_header "Shell (experimental)"
+	section_header "Shell"
 	if $HAS_GUM; then
 		gum_selected=""
 		case "$shell_prev" in
-			zsh) gum_selected="zsh (experimental)" ;;
+			zsh)  gum_selected="zsh (experimental)" ;;
+			fish) gum_selected="fish (experimental)" ;;
 			bash) gum_selected="bash" ;;
 		esac
 		gum_args=(--header "Select default shell:")
 		[ -n "$gum_selected" ] && gum_args+=(--selected "$gum_selected")
-		shell_pick=$(gum choose "${gum_args[@]}" "bash" "zsh (experimental)") || shell_pick=""
+		shell_pick=$(gum choose "${gum_args[@]}" "bash" "zsh (experimental)" "fish (experimental)") || shell_pick=""
 		case "$shell_pick" in
-			"zsh (experimental)") shell_choice="zsh" ;;
-			"bash")               shell_choice="bash" ;;
-			*)                    shell_choice="$shell_prev" ;;
+			"zsh (experimental)")  shell_choice="zsh" ;;
+			"fish (experimental)") shell_choice="fish" ;;
+			"bash")                shell_choice="bash" ;;
+			*)                     shell_choice="$shell_prev" ;;
 		esac
 	else
 		echo "Select default shell:"
-		for sh_item in "1:bash:GNU Bash (default)" "2:zsh:Zsh + Oh My Zsh + autosuggestions + syntax highlighting (experimental)"; do
+		for sh_item in \
+			"1:bash:GNU Bash (default)" \
+			"2:zsh:Zsh + Oh My Zsh + autosuggestions + syntax highlighting (experimental)" \
+			"3:fish:Fish shell with built-in autosuggestions and syntax highlighting (experimental)"; do
 			num="${sh_item%%:*}"; rest="${sh_item#*:}"; key="${rest%%:*}"; desc="${rest#*:}"
 			if [ "$key" = "$shell_prev" ]; then
 				echo "  ${num}) ${key} — ${desc} [current]"
@@ -1329,13 +1334,14 @@ if $INTERACTIVE; then
 				echo "  ${num}) ${key} — ${desc}"
 			fi
 		done
-		read -rp "Selection [1,2/skip]: " shell_selection
+		read -rp "Selection [1,2,3/skip]: " shell_selection
 		if [ -z "$shell_selection" ] && [ -n "$shell_prev" ]; then
 			shell_choice="$shell_prev"
 		else
 			case "$shell_selection" in
 				1) shell_choice="bash" ;;
 				2) shell_choice="zsh" ;;
+				3) shell_choice="fish" ;;
 				*) shell_choice="${shell_prev:-bash}" ;;
 			esac
 		fi
@@ -1344,7 +1350,10 @@ if $INTERACTIVE; then
 	echo "$shell_choice" > "$SHELL_CONFIG"
 elif [ -n "$shell_prev" ]; then
 	shell_choice="$shell_prev"
-	[ "$shell_choice" = "zsh" ] && echo "Configuring shell: zsh (from previous selection)"
+	case "$shell_choice" in
+		zsh)  echo "Configuring shell: zsh (from previous selection)" ;;
+		fish) echo "Configuring shell: fish (from previous selection)" ;;
+	esac
 else
 	shell_choice="bash"
 	echo "$shell_choice" > "$SHELL_CONFIG"
@@ -1423,18 +1432,123 @@ install_zsh() {
 	run_with_spinner "Installing Zsh + Oh My Zsh..." _install_zsh_inner
 }
 
+# Translate one bash-syntax line from a ~/.squarebox-* alias/path file into
+# its fish equivalent on stdout. Handles:
+#   export PATH="A:B:$PATH"          → set -x PATH A B $PATH
+#   export NAME='value'              → set -x NAME value
+#   alias name='cmd'                 → passed through (fish accepts this form)
+# Bash-only constructs (nvm sourcing, [ -s ... ] && . ..., etc.) are dropped;
+# users who need nvm in fish should install a fish plugin (e.g. nvm.fish).
+_squarebox_bash_line_to_fish() {
+	local line="$1"
+	case "$line" in
+		"export PATH="*)
+			local val="${line#export PATH=}"
+			val="${val#\"}"; val="${val%\"}"
+			val="${val#\'}"; val="${val%\'}"
+			echo "set -x PATH ${val//:/ }"
+			;;
+		"export "*=*)
+			local rest="${line#export }"
+			local name="${rest%%=*}"
+			local val="${rest#*=}"
+			val="${val#\"}"; val="${val%\"}"
+			val="${val#\'}"; val="${val%\'}"
+			echo "set -x $name $val"
+			;;
+		"alias "*=*)
+			echo "$line"
+			;;
+	esac
+}
+
+_install_fish_inner() {
+	sudo apt-get update -qq && sudo apt-get install -y -qq fish >/dev/null 2>&1 || return 1
+	command -v fish >/dev/null 2>&1 || return 1
+	mkdir -p "$HOME/.config/fish/conf.d" || return 1
+	# Generate ~/.config/fish/config.fish mirroring the default bashrc in
+	# fish-native syntax. Fish has built-in autosuggestions and syntax
+	# highlighting, so no plugins are needed.
+	cat > "$HOME/.config/fish/config.fish" <<-'FISHRC' || return 1
+		# squarebox fish config (experimental) — mirrors ~/.bashrc
+		status is-interactive; or exit 0
+
+		starship init fish | source
+		zoxide init fish --cmd cd | source
+
+		alias ls='eza --icons'
+		alias ll='eza -la --icons'
+		alias lsa='ls -a'
+		alias lt='eza --tree --level=2 --long --icons --git'
+		alias lta='lt -a'
+		alias cat='bat --paging=never'
+		alias ff="fzf --preview 'bat --style=numbers --color=always {}'"
+		alias eff='$EDITOR (ff)'
+		alias ..='cd ..'
+		alias ...='cd ../..'
+		alias ....='cd ../../..'
+		alias g='git'
+		alias gcm='git commit -m'
+		alias gcam='git commit -a -m'
+		alias gcad='git commit -a --amend'
+
+		set -x EDITOR nano
+		fish_add_path -g $HOME/.local/bin
+
+		# User selections translated from bash files at install time.
+		test -f $HOME/.config/fish/conf.d/squarebox-selections.fish
+			and source $HOME/.config/fish/conf.d/squarebox-selections.fish
+
+		test -x ~/motd.sh; and ~/motd.sh
+	FISHRC
+	[ -f "$HOME/.config/fish/config.fish" ] || return 1
+
+	# Translate AI/editor/TUI/SDK bash-syntax files into a single fish
+	# conf.d snippet. Regenerated each install to reflect current selections.
+	local sel_out="$HOME/.config/fish/conf.d/squarebox-selections.fish"
+	{
+		echo "# Generated by setup.sh from ~/.squarebox-* bash files."
+		for src in \
+			"$HOME/.squarebox-ai-aliases" \
+			"$HOME/.squarebox-editor-aliases" \
+			"$HOME/.squarebox-tui-aliases" \
+			"$HOME/.squarebox-sdk-paths"; do
+			[ -f "$src" ] || continue
+			echo "# --- from $(basename "$src") ---"
+			while IFS= read -r _sq_line; do
+				_squarebox_bash_line_to_fish "$_sq_line"
+			done < "$src"
+		done
+	} > "$sel_out" || return 1
+}
+
+install_fish() {
+	run_with_spinner "Installing Fish..." _install_fish_inner
+}
+
 case "$shell_choice" in
 	zsh)
 		if install_zsh; then
 			touch ~/.squarebox-use-zsh
+			rm -f ~/.squarebox-use-fish
 			echo "Zsh will take over at the end of this setup (next interactive shell)."
 		else
 			echo "Warning: Zsh installation failed; staying on bash."
+			rm -f ~/.squarebox-use-zsh ~/.squarebox-use-fish
+		fi
+		;;
+	fish)
+		if install_fish; then
+			touch ~/.squarebox-use-fish
 			rm -f ~/.squarebox-use-zsh
+			echo "Fish will take over at the end of this setup (next interactive shell)."
+		else
+			echo "Warning: Fish installation failed; staying on bash."
+			rm -f ~/.squarebox-use-zsh ~/.squarebox-use-fish
 		fi
 		;;
 	bash|*)
-		rm -f ~/.squarebox-use-zsh
+		rm -f ~/.squarebox-use-zsh ~/.squarebox-use-fish
 		;;
 esac
 fi # should_run shell

--- a/setup.sh
+++ b/setup.sh
@@ -1471,7 +1471,9 @@ _install_fish_inner() {
 	# highlighting, so no plugins are needed.
 	cat > "$HOME/.config/fish/config.fish" <<-'FISHRC' || return 1
 		# squarebox fish config (experimental) — mirrors ~/.bashrc
-		status is-interactive; or exit 0
+		# Use `return` (not `exit`) so non-interactive invocations like
+		# `fish -c '…'` skip this config without terminating the shell.
+		status is-interactive; or return
 
 		starship init fish | source
 		zoxide init fish --cmd cd | source


### PR DESCRIPTION
## Summary

- Adds **fish** as a third shell option alongside bash and zsh in `setup.sh`, flagged as experimental.
- Drops `(experimental)` from the Shell section header since the tag now lives on the individual options.
- Generates a fish-native `~/.config/fish/config.fish` mirroring the default bashrc (starship, zoxide, aliases, EDITOR, PATH), plus a translated `conf.d/squarebox-selections.fish` built from the user's existing `~/.squarebox-ai-aliases`, `-editor-aliases`, `-tui-aliases`, and `-sdk-paths` bash files.
- Mirrors the zsh handoff: `~/.squarebox-use-fish` marker causes `~/.bashrc` to `exec fish -l`; `SQUAREBOX_IN_FISH` guards re-exec loops, `SQUAREBOX_NO_FISH` forces bash for one session.

## Why

Fish is the most-requested alternative after zsh — built-in autosuggestions and syntax highlighting with no plugins required. Existing users who prefer fish had to configure it manually.

## Notes for reviewers

- **Bash→fish translation** (`_squarebox_bash_line_to_fish` in `setup.sh`): handles `export PATH="A:B:\$PATH"` → `set -x PATH A B \$PATH`, other `export NAME=…` → `set -x NAME …`, and passes `alias …` lines through (fish 3+ accepts `alias foo='bar'`). Lines it can't translate (the nvm `[ -s … ] && . …` sourcing, etc.) are dropped on purpose — see the known limitation below.
- **Known limitation**: nvm isn't wired into fish. The README flags this and points at [nvm.fish](https://github.com/jorgebucaran/nvm.fish). All other SDKs (uv, Go, .NET) translate cleanly since they use plain `export`.
- **Dockerfile** gets a parallel handoff stanza after the existing zsh one; selection logic clears whichever marker the user isn't using.
- **e2e test** now clears both markers before asserting bash selection state — fish path isn't exercised in CI (same rationale as zsh: network-heavy apt install).

## Test plan

- [ ] Fresh container → `sqrbx-setup shell` → pick fish → exit/re-enter → lands in fish with prompt, aliases, and selected EDITOR working
- [ ] Re-run `sqrbx-setup shell` → switch back to bash → marker removed, next shell is bash
- [ ] `SQUAREBOX_NO_FISH=1 bash -l` (with marker present) → stays in bash
- [ ] `cat ~/.config/fish/conf.d/squarebox-selections.fish` → contains the expected translated entries for the current selections
- [ ] Existing bash and zsh flows still work (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)