### PR TITLE
docs: collapse Docker install section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ asks which to use. Override with `SQUAREBOX_RUNTIME=docker` or
 > have rough edges around volume mounts, SSH agent forwarding, or rebuild
 > flows — please file an issue if you hit one.
 
-### Don't have Docker or Podman? One-line install
+<details>
+<summary><strong>Don't have Docker or Podman? One-line install</strong></summary>
 
 **macOS** (via [Homebrew](https://brew.sh)):
 
@@ -49,6 +50,8 @@ Log out and back in (or run `newgrp docker`) so your shell picks up the new grou
 
 On macOS and Windows, start Docker Desktop once after install so the daemon is
 running before you continue.
+
+</details>
 
 Install
 -------


### PR DESCRIPTION
## Summary
- Wraps the "Don't have Docker or Podman? One-line install" subsection in a `<details>`/`<summary>` block so it renders collapsed by default on GitHub.
- Reduces visual noise in the README for the common case where the reader already has Docker or Podman installed; the one-liner install steps are still one click away.

## Notes for reviewer
- The section is no longer a Markdown heading, so it will not appear in GitHub's auto-generated table of contents. If we want it back in the TOC, we can nest a `### ` heading inside the `<summary>` element.

## Test plan
- [ ] Verify the rendered README on GitHub shows the section collapsed by default with a clickable disclosure triangle.
- [ ] Expand it and confirm the macOS / Linux / Windows install snippets render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)