### PR TITLE
docs: restructure roadmap by effort tier; prune speculative items

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,22 +1,17 @@
 # Roadmap
 
-## Planned
+Grouped by effort, not priority. Near-term items are small additive changes;
+medium items touch `setup.sh` or shared configs.
 
-Items are listed in priority order.
+## Near-term
 
-- **direnv** — add [direnv](https://github.com/direnv/direnv) (automatic per-directory environment loading) to the default image; auto-loads `.envrc` files on `cd`, integrates with zoxide for seamless per-project environment variables
-- **Dotfile portability** — let users mount or bootstrap their own dotfiles (starship.toml, tmux.conf, aliases, etc.) via a `~/.squarebox/` convention, with sensible merge/override behaviour against the defaults
-- **MCP server pre-configuration** — ship ready-made MCP server configs (filesystem, GitHub, etc.) as part of the AI assistant setup step
-- **hyperfine** — add [hyperfine](https://github.com/sharkdp/hyperfine) (command-line benchmarking) to the default image
-- **Atuin (searchable shell history)** — replace basic bash history with full-text search, sync, and stats across sessions
-- **Host theme transparency** — configure tools (fzf, eza, starship, tmux) to use ANSI colour references so they inherit the host terminal's theme automatically; provide sensible defaults for tools with their own named themes (bat, delta) with easy overrides
-- **Per-project container profiles** — save and load named profiles (e.g. `sqrbx start --profile python-ml`) that pre-select SDKs, editors, and AI tools without re-running the wizard
-- **Neovim defaults from omarchy** — bring across the neovim configuration defaults from omarchy so nvim works well out of the box
-- **Task completion notifications** — webhook, terminal bell, or desktop notification when long-running AI tasks finish
-- **Network firewall / sandboxing mode** — optional network-level isolation (iptables/seccomp) so AI agents can only reach approved endpoints, inspired by trailofbits and clampdown
-- **Multiple concurrent container instances** — support running more than one squarebox container simultaneously
-- **Multi-agent workflow orchestration** — explore adding a layer to run multiple AI coding agents simultaneously in isolated contexts (git worktrees + tmux sessions), inspired by agent-of-empires; may be better to integrate an existing tool than build from scratch
-- ~~**just**~~ — ✅ done: [just](https://github.com/casey/just) pinned in the Dockerfile tier with SHA256 checksums
-- ~~**difftastic**~~ — ✅ done: [difftastic](https://github.com/Wilfred/difftastic) (`difft`) pinned in the Dockerfile tier with SHA256 checksums
-- ~~**Podman compatibility**~~ — ✅ done: install scripts auto-detect Docker or Podman and skip UID chown logic for Podman's rootless user namespace mapping
-- ~~**Zsh option**~~ — ✅ done (experimental): `setup.sh` now offers Zsh with Oh My Zsh, autosuggestions, and syntax highlighting as a selectable shell alongside the Bash default; opt in via the new `shell` setup section
+- **direnv** — [direnv](https://github.com/direnv/direnv) for automatic per-directory environment loading via `.envrc`; pinned in the Dockerfile tier.
+- **hyperfine** — [hyperfine](https://github.com/sharkdp/hyperfine) command-line benchmarking; pinned in the Dockerfile tier.
+- **Terminal bell on AI task completion** — emit a terminal bell when long-running AI commands finish, via a wrapper around the AI aliases.
+
+## Medium
+
+- **Atuin** — replace basic bash history with full-text search, sync, and stats across sessions.
+- **Host theme transparency** — configure tools (fzf, eza, starship, tmux, zellij) to use ANSI colour references so they inherit the host terminal's theme; provide sensible defaults for tools with their own named themes (bat, delta) with easy overrides.
+- **Neovim defaults from omarchy** — cherry-pick the omarchy neovim configuration so nvim works well out of the box when selected during setup.
+- **Dotfile portability** — let users mount or bootstrap their own dotfiles (starship.toml, tmux.conf, aliases, etc.) via a `~/.squarebox/` convention, with sensible merge/override behaviour against the defaults.


### PR DESCRIPTION
## Summary

- Regroup roadmap by effort (Near-term / Medium) rather than flat priority order, since the prior list mixed one-line Dockerfile ARG bumps with multi-week orchestration layers.
- Prune items that had grown fuzzy or speculative: MCP pre-configuration, per-project container profiles, multiple concurrent instances, multi-agent orchestration, and network firewall / sandboxing.
- Narrow the "task completion notifications" item down to just the terminal bell — the webhook / desktop variants were the speculative parts.
- Drop the completed strike-throughs (just, difftastic, Podman, Zsh); they've been sitting in the file for a while and shipped features belong in release notes, not the roadmap.

## Remaining items

**Near-term:** direnv, hyperfine, terminal bell on AI task completion.

**Medium:** Atuin, host theme transparency, Neovim defaults from omarchy, dotfile portability.

## Test plan

- [ ] ROADMAP.md renders correctly on GitHub (headings, lists, links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)