### PR TITLE
feat: offer LazyVim starter config when Neovim is selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ Nano is always available as the default editor.
 | [helix](https://github.com/helix-editor/helix) | Rust | Modal editor (Kakoune-inspired) - *coming soon* |
 | [nvim](https://github.com/neovim/neovim) | C/Lua | Neovim |
 
+Selecting **nvim** offers to install the [LazyVim](https://www.lazyvim.org/) starter config to `~/.config/nvim`, turning Neovim into a preconfigured IDE. Plugins sync on first launch and persist in the `squarebox-home` volume. A Nerd Font in your terminal is recommended for icons; the starter is skipped if `~/.config/nvim` already exists, so your own config is never overwritten.
+
 ### TUI Tools
 
 Installed during first-run setup. Choose any combination:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,5 +13,4 @@ medium items touch `setup.sh` or shared configs.
 
 - **Atuin** — replace basic bash history with full-text search, sync, and stats across sessions.
 - **Host theme transparency** — configure tools (fzf, eza, starship, tmux, zellij) to use ANSI colour references so they inherit the host terminal's theme; provide sensible defaults for tools with their own named themes (bat, delta) with easy overrides.
-- **Neovim defaults from omarchy** — cherry-pick the omarchy neovim configuration so nvim works well out of the box when selected during setup.
 - **Dotfile portability** — let users mount or bootstrap their own dotfiles (starship.toml, tmux.conf, aliases, etc.) via a `~/.squarebox/` convention, with sensible merge/override behaviour against the defaults.

--- a/scripts/squarebox-setup.sh
+++ b/scripts/squarebox-setup.sh
@@ -90,6 +90,18 @@ show_list() {
 			printf "  ${CYAN}%-18s${RESET}${DIM}(none)${RESET}\n" "${label}:"
 		fi
 	done
+
+	# LazyVim starter (sub-option of the nvim editor)
+	local editors_val="" lazyvim_val=""
+	[ -f /workspace/.squarebox/editors ] && editors_val=$(cat /workspace/.squarebox/editors)
+	if [[ ",$editors_val," == *",nvim,"* ]]; then
+		[ -f /workspace/.squarebox/nvim-lazyvim ] && lazyvim_val=$(cat /workspace/.squarebox/nvim-lazyvim)
+		if [ "$lazyvim_val" = "true" ]; then
+			printf "  ${CYAN}%-18s${RESET}%s\n" "LazyVim:" "enabled"
+		else
+			printf "  ${CYAN}%-18s${RESET}${DIM}disabled${RESET}\n" "LazyVim:"
+		fi
+	fi
 	echo
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -569,6 +569,34 @@ else
 	echo "$editor_list" > "$EDITOR_CONFIG"
 fi
 
+# LazyVim starter — offered when Neovim is among the selected editors
+LAZYVIM_CONFIG="/workspace/.squarebox/nvim-lazyvim"
+lazyvim_prev=""
+[ -f "$LAZYVIM_CONFIG" ] && lazyvim_prev=$(cat "$LAZYVIM_CONFIG")
+lazyvim_choice=false
+if [[ ",$editor_list," == *",nvim,"* ]]; then
+	if $INTERACTIVE; then
+		lv_default=true
+		[ "$lazyvim_prev" = "false" ] && lv_default=false
+		echo
+		echo "LazyVim turns Neovim into a preconfigured IDE (needs a Nerd Font in your terminal for icons)."
+		if $HAS_GUM; then
+			gum confirm "Install the LazyVim starter config for Neovim?" --default="$lv_default" && lazyvim_choice=true || lazyvim_choice=false
+		else
+			if $lv_default; then _lv_hint="Y/n"; else _lv_hint="y/N"; fi
+			read -rp "Install the LazyVim starter config for Neovim? [$_lv_hint]: " _lv_reply
+			if [ -z "$_lv_reply" ]; then
+				lazyvim_choice=$lv_default
+			else
+				case "$_lv_reply" in [Yy]*) lazyvim_choice=true ;; *) lazyvim_choice=false ;; esac
+			fi
+		fi
+		echo "$lazyvim_choice" > "$LAZYVIM_CONFIG"
+	elif [ -n "$lazyvim_prev" ]; then
+		lazyvim_choice="$lazyvim_prev"
+	fi
+fi
+
 install_micro() {
 	if command -v micro &>/dev/null; then echo "Micro already installed, skipping."; return 0; fi
 	run_with_spinner "Installing Micro..." sb_install micro latest
@@ -589,6 +617,23 @@ install_nvim() {
 	run_with_spinner "Installing Neovim..." sb_install nvim latest
 }
 
+install_lazyvim() {
+	if [ -e ~/.config/nvim ]; then
+		echo "~/.config/nvim already exists, skipping LazyVim starter clone."
+		return 0
+	fi
+	run_with_spinner "Installing LazyVim starter..." _install_lazyvim_inner
+}
+
+_install_lazyvim_inner() {
+	# nvim-treesitter compiles parsers on first launch, which needs a C compiler
+	if ! command -v cc &>/dev/null && ! command -v gcc &>/dev/null; then
+		sudo apt-get update -qq && sudo apt-get install -y -qq build-essential >/dev/null 2>&1 || return 1
+	fi
+	git clone --depth 1 https://github.com/LazyVim/starter ~/.config/nvim >/dev/null 2>&1 || return 1
+	rm -rf ~/.config/nvim/.git
+}
+
 installed_editors=()
 for editor in $(echo "$editor_list" | tr ',' ' '); do
 	case "$editor" in
@@ -598,6 +643,11 @@ for editor in $(echo "$editor_list" | tr ',' ' '); do
 		nvim) install_nvim && installed_editors+=("nvim") || echo "Warning: Neovim installation failed." ;;
 	esac
 done
+
+# Bootstrap LazyVim starter config when chosen and Neovim is available
+if [ "$lazyvim_choice" = "true" ] && command -v nvim &>/dev/null; then
+	install_lazyvim || echo "Warning: LazyVim starter setup failed."
+fi
 
 # Prompt for default editor if multiple were installed
 editor_cmd=""


### PR DESCRIPTION
When nvim is chosen in the editor setup, prompt to install the LazyVim
starter into ~/.config/nvim (skipped if a config already exists, so a
user's own config is never clobbered). Installs build-essential on demand
since nvim-treesitter compiles parsers on first launch. The choice persists
to /workspace/.squarebox/nvim-lazyvim and is surfaced in sqrbx-setup --list.

Supersedes the "Neovim defaults from omarchy" roadmap item.

https://claude.ai/code/session_016nYRxhVQCoDaie2QNzo9oi