### PR TITLE
feat: add hands-on AI agent coach mode to sqrbx-learn

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,16 +236,26 @@ and fish.
 ### Learning mode (beta)
 
 Optional. When enabled during first-run setup (or via `sqrbx-setup learn`),
-the container ships an interactive tutorial covering every tool in the
-toolkit — history, why-it-exists, and skill-level-adapted "try it" examples.
+the container ships an interactive guide to every tool in the toolkit —
+history, why-it-exists, and skill-level-adapted "try it" examples.
 
-    sqrbx-learn               # start or continue lessons
+    sqrbx-learn               # open the menu
+    sqrbx-learn rg            # jump straight to a tool's lesson
     sqrbx-learn --progress    # show what you've completed
     sqrbx-learn --reset       # wipe progress AND skill level
 
+The top menu entry, **Learn hands-on with your AI agent**, launches Claude
+Code in a coaching mode for the session: instead of doing the work for you,
+it explains each step, hands you the exact command and the reason for the
+tool choice, and asks you to run it yourself. Say "just do it" at any point
+to let it take over. It's injected via `--append-system-prompt`, so it's
+session-scoped and never touches your workspace's own `CLAUDE.md`. (Requires
+Claude Code; add it with `sqrbx-setup ai`.)
+
 The first launch asks for a skill level (beginner / intermediate / expert)
-to scale the examples; you can change it later from the menu. Lessons render
-through `glow` when available so the markdown bodies display properly.
+to scale both the examples and the agent's coaching; you can change it later
+from the menu. Lessons render through `glow` when available so the markdown
+bodies display properly.
 
 Aliases
 -------

--- a/motd.sh
+++ b/motd.sh
@@ -41,6 +41,6 @@ fi
 
 # Learn mode hint
 if [ -f "/workspace/.squarebox/learn" ] && grep -qx "enabled" /workspace/.squarebox/learn 2>/dev/null; then
-	printf '\e[38;5;208m  ✦ sqrbx-learn\e[0m\e[38;5;245m — type to start learning\e[0m\n'
+	printf '\e[38;5;208m  ✦ sqrbx-learn\e[0m\e[38;5;245m — learn the toolkit hands-on with your AI agent\e[0m\n'
 fi
 echo

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -265,6 +265,8 @@ suite_setup_editors() {
 	run_test_grep "3.13b learn config persists" "enabled" cat /workspace/.squarebox/learn
 	run_test "3.13c sqrbx-learn --help exits 0" sqrbx-learn --help
 	run_test_grep "3.13d motd shows learn hint when enabled" "sqrbx-learn" bash /usr/local/lib/squarebox/motd.sh
+	run_test_grep "3.13e help documents hands-on agent mode" "hands-on" sqrbx-learn --help
+	run_test "3.13f unknown lesson arg errors" bash -c '! sqrbx-learn __no_such_tool__ 2>/dev/null'
 }
 
 # ── Suite: update ────────────────────────────────────────────────────────

--- a/scripts/sqrbx-learn
+++ b/scripts/sqrbx-learn
@@ -1348,8 +1348,9 @@ run_lesson_by_arg() {
 		echo "sqrbx-learn: lessons need an interactive terminal." >&2
 		return 1
 	fi
-	# Try-it examples need a skill level; default rather than forcing the wizard.
-	[ -z "$(progress_get skill_level)" ] && progress_set "skill_level" "beginner"
+	# skill_level() defaults to "beginner" when unset, so a deep-linked lesson
+	# scales correctly without persisting a level — that keeps the first-run
+	# skill assessment intact for when the operator opens the full menu.
 	"lesson_${id}" || true
 }
 

--- a/scripts/sqrbx-learn
+++ b/scripts/sqrbx-learn
@@ -3,7 +3,8 @@
 # Teaches the history and usage of each tool in the squarebox toolkit.
 #
 # Usage:
-#   sqrbx-learn            Start or continue learning
+#   sqrbx-learn            Open the menu (hands-on AI agent mode, or browse lessons)
+#   sqrbx-learn <tool>     Jump straight to a tool's lesson (e.g. sqrbx-learn rg)
 #   sqrbx-learn --progress Show your progress
 #   sqrbx-learn --reset    Reset all progress AND skill level
 #   sqrbx-learn --help     Show this help
@@ -1235,6 +1236,123 @@ EOF
 	gum confirm "Mark '${title}' as complete?" --default=true && mark_complete "$id" && green "✓ Marked complete"
 }
 
+# ── Hands-on AI agent (coach mode) ────────────────────────────────────────────
+# Launches the AI coding agent with a "teach me while we work" instruction
+# appended for this session only. The teaching itself is a portable prompt
+# (tutor_prompt) — only the injection is harness-specific. Claude Code's
+# --append-system-prompt lets us inject the coaching persona without touching
+# the workspace's own CLAUDE.md, so it stays session-scoped and opt-in.
+
+tutor_prompt() {
+	local sl; sl=$(skill_level)
+	printf 'You are pairing inside squarebox with someone whose self-described terminal skill level is: %s. Calibrate every explanation to that level.\n\n' "$sl"
+	cat <<'EOF'
+# squarebox hands-on learning session
+
+You are not just here to finish the task. Your job is to help the operator
+LEARN the modern terminal toolkit by doing the work themselves. Treat this as
+pair programming where they hold the keyboard.
+
+## How to behave
+
+- Default to coaching, not autopiloting. For each step: explain the plan in one
+  or two sentences, then give the EXACT command to run plus a one-line reason for
+  the tool choice, and ask the operator to run it themselves and tell you what
+  they saw. Wait for their result before moving on.
+- Only run a command yourself when it is purely tedious, unsafe to get wrong, or
+  when the operator says something like "just do it" or "take over". When they
+  say that, comply for the rest of that task without arguing.
+- Teach one concept at a time. Keep asides short. Do not lecture.
+- When a step touches a tool the operator may not know, name the modern tool,
+  what it replaces, and the single reason it is better — then point them at the
+  matching lesson with `sqrbx-learn <tool>` (e.g. `sqrbx-learn rg`) for depth.
+
+## The squarebox toolkit (prefer these and explain why)
+
+- rg (ripgrep) over grep — faster, respects .gitignore
+- fd over find — simpler syntax, sane defaults
+- bat over cat — syntax highlighting (already aliased to `cat`)
+- eza over ls — icons and git status (already aliased to `ls`)
+- zoxide over cd — frecency jumps (already aliased to `cd`)
+- fzf — fuzzy-pick anything (Ctrl-T files, Ctrl-R history, Alt-C dirs)
+- delta — syntax-highlighted git diffs (git's default pager here)
+- difft (difftastic) — structural, syntax-aware diffs
+- yq — jq for YAML/JSON; xh — a friendlier curl; just — a modern make
+- glow — render markdown; gum — build interactive shell scripts
+- gh — GitHub from the terminal; lazygit — a git TUI; yazi — a file manager
+
+## Boundaries
+
+- The task still has to end up correct — never trade a working result for a
+  teaching moment. If the operator's command is wrong, explain why and let them
+  retry before you correct it for them.
+- This is a real workspace, not a sandbox. Be careful with destructive commands
+  and always explain the risk before suggesting one.
+EOF
+}
+
+launch_agent_tutor() {
+	if ! command -v claude >/dev/null 2>&1; then
+		echo
+		gum style --foreground 214 "Hands-on agent mode currently supports Claude Code, which isn't installed."
+		dim "Add it with: sqrbx-setup ai"
+		sleep 2
+		return 0
+	fi
+	echo
+	green "Launching Claude in hands-on coach mode (skill: $(skill_level))…"
+	dim "It hands you commands to run yourself. Say \"just do it\" to let it take over."
+	dim "Exit Claude to return to this menu."
+	echo
+	claude --append-system-prompt "$(tutor_prompt)" || true
+}
+
+# ── Lesson deep-linking ───────────────────────────────────────────────────────
+# Resolve a friendly argument (tool name or lesson id) to a lesson id so the
+# menu's lessons can be opened directly, e.g. `sqrbx-learn rg`.
+
+resolve_lesson_id() {
+	local arg; arg=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+	local cat id title tool always
+	for entry in "${ALL_LESSONS[@]}"; do
+		IFS='|' read -r cat id title tool always <<< "$entry"
+		if [ "$arg" = "$id" ] || [ "$arg" = "$tool" ]; then
+			echo "$id"; return 0
+		fi
+	done
+	case "$arg" in
+		ripgrep)          echo "rg_vs_grep"      ;;
+		find)             echo "fd_vs_find"      ;;
+		cat)              echo "bat_vs_cat"      ;;
+		ls)               echo "eza_vs_ls"       ;;
+		cd)               echo "zoxide_cd"       ;;
+		difftastic)       echo "difftastic"      ;;
+		curl|http|httpie) echo "xh_http"         ;;
+		make)             echo "just_taskrunner" ;;
+		pipe|pipes)       echo "unix_pipes"      ;;
+		unix|philosophy)  echo "unix_philosophy" ;;
+		*)                return 1               ;;
+	esac
+	return 0
+}
+
+run_lesson_by_arg() {
+	local arg="$1" id
+	if ! id=$(resolve_lesson_id "$arg"); then
+		echo "sqrbx-learn: no lesson matches '$arg'." >&2
+		echo "Run 'sqrbx-learn' with no arguments to see the full list." >&2
+		return 1
+	fi
+	require_gum
+	if ! [ -t 0 ] || ! [ -t 1 ]; then
+		echo "sqrbx-learn: lessons need an interactive terminal." >&2
+		return 1
+	fi
+	# Try-it examples need a skill level; default rather than forcing the wizard.
+	[ -z "$(progress_get skill_level)" ] && progress_set "skill_level" "beginner"
+	"lesson_${id}" || true
+}
+
 # ── Main menu ────────────────────────────────────────────────────────────────
 
 show_banner() {
@@ -1269,8 +1387,11 @@ main() {
 		local -a menu_entries
 		build_menu menu_entries
 
+		# Agent coach mode is the headline entry; lessons follow.
+		local agent_label="🤖 Learn hands-on with your AI agent"
+
 		# Extract display labels for gum choose
-		local -a labels=()
+		local -a labels=("$agent_label")
 		for entry in "${menu_entries[@]+"${menu_entries[@]}"}"; do
 			labels+=("${entry%%|*}")
 		done
@@ -1279,10 +1400,14 @@ main() {
 		local choice
 		choice=$(gum choose \
 			--height 24 \
-			--header "Select a lesson (↑↓ or jk to navigate, enter to select):" \
+			--header "Pick how to learn (↑↓ or jk to navigate, enter to select):" \
 			"${labels[@]}") || break
 
 		case "$choice" in
+			"$agent_label")
+				launch_agent_tutor
+				continue
+				;;
 			"── Exit") break ;;
 			"── Change skill level")
 				skill_assessment
@@ -1324,10 +1449,15 @@ usage() {
 	sqrbx-learn — interactive terminal learning guide
 
 	Usage:
-	  sqrbx-learn            Start or continue learning
+	  sqrbx-learn            Open the menu (hands-on AI agent mode, or browse lessons)
+	  sqrbx-learn <tool>     Jump straight to a tool's lesson (e.g. sqrbx-learn rg)
 	  sqrbx-learn --progress Show your progress
 	  sqrbx-learn --reset    Reset all progress AND skill level (re-prompts on next launch)
 	  sqrbx-learn --help     Show this help
+
+	Hands-on agent mode (the top menu entry) launches Claude Code as a coach for
+	the session: instead of doing the work for you, it hands you each command to
+	run yourself and explains why. Say "just do it" to let it take over.
 
 	Inside the guide:
 	  ↑↓ / jk    Navigate lessons
@@ -1362,9 +1492,12 @@ case "${1:-}" in
 	"")
 		main
 		;;
-	*)
+	-*)
 		echo "Unknown option: $1" >&2
 		usage >&2
 		exit 1
+		;;
+	*)
+		run_lesson_by_arg "$1" || exit 1
 		;;
 esac

--- a/setup.sh
+++ b/setup.sh
@@ -1534,7 +1534,8 @@ if $INTERACTIVE; then
 		echo "── Learn Mode ──────────────────────────────────────────────────────────────"
 	fi
 	echo "sqrbx-learn is an interactive guide to the tools in your squarebox,"
-	echo "covering their history and how to use them effectively."
+	echo "covering their history and how to use them effectively. It can also"
+	echo "launch your AI agent in a hands-on coach mode that teaches as you work."
 	echo
 
 	if $HAS_GUM; then


### PR DESCRIPTION
Make learn mode interactive by teaching during real work instead of only
through the standalone lesson browser. The top menu entry now launches
Claude Code with a session-scoped coaching prompt (--append-system-prompt):
rather than autopiloting, the agent hands the operator each command to run
themselves and explains the tool choice, adapting to the recorded skill
level. The coaching persona is a portable prompt; only the injection is
harness-specific, so other agents can be wired in later.

Also adds `sqrbx-learn <tool>` deep-linking so a lesson opens directly
(e.g. `sqrbx-learn rg`), which the agent points to for depth. Updates the
MOTD hint, README, and e2e coverage.

https://claude.ai/code/session_01CVTrXoHjLqt3gEUQHT6AS6