### PR TITLE
fix(devcontainer): open the cloned repo and install a default toolset

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,5 +12,5 @@
   "mounts": [
     "source=/etc/localtime,target=/etc/localtime,type=bind,readonly"
   ],
-  "postCreateCommand": "bash ${containerWorkspaceFolder}/scripts/devcontainer-postcreate.sh"
+  "postCreateCommand": ["bash", "${containerWorkspaceFolder}/scripts/devcontainer-postcreate.sh"]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,12 +4,13 @@
     "context": "..",
     "dockerfile": "../Dockerfile"
   },
-  "workspaceFolder": "/workspace",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
   "remoteUser": "dev",
   "containerEnv": {
     "DEVCONTAINER": "1"
   },
   "mounts": [
     "source=/etc/localtime,target=/etc/localtime,type=bind,readonly"
-  ]
+  ],
+  "postCreateCommand": "bash ${containerWorkspaceFolder}/scripts/devcontainer-postcreate.sh"
 }

--- a/README.md
+++ b/README.md
@@ -388,10 +388,22 @@ Open this repo in VS Code with the
 [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers),
 or launch it in [GitHub Codespaces](https://github.com/features/codespaces).
 The included `.devcontainer/devcontainer.json` builds the full **squarebox** image
-automatically.
+automatically and opens the cloned repo at `/workspaces/<repo>`.
 
-The interactive first-run setup is skipped in devcontainer mode. To configure
-AI tools or SDKs, run `sqrbx-setup` from the integrated terminal.
+The interactive first-run wizard can't run in devcontainer mode (no TTY at
+create time), so a default toolset — **Claude Code + Node.js** — is installed
+non-interactively by `postCreateCommand`. Override the defaults with these
+container environment variables (set to an empty string to opt out of a tier):
+
+| Variable | Default | Selects |
+|----------|---------|---------|
+| `SQUAREBOX_DC_AI` | `claude` | AI assistants (`claude,copilot,gemini,codex,opencode,pi`) |
+| `SQUAREBOX_DC_SDKS` | `node` | SDKs (`node,python,go,dotnet,rust`) |
+| `SQUAREBOX_DC_EDITORS` | _(none)_ | Editors (`micro,edit,fresh,nvim`) |
+| `SQUAREBOX_DC_TUIS` | _(none)_ | TUI tools (`lazygit,gh-dash,yazi`) |
+
+To add or change tools after the fact, run `sqrbx-setup` from the integrated
+terminal.
 
 You can also attach to a running codespace directly from your local terminal
 using `gh codespace ssh`.

--- a/scripts/devcontainer-postcreate.sh
+++ b/scripts/devcontainer-postcreate.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# devcontainer-postcreate.sh — non-interactive squarebox setup for
+# Dev Containers / GitHub Codespaces.
+#
+# The interactive first-run wizard (setup.sh via .bashrc) is skipped when
+# DEVCONTAINER=1, because there is no TTY at container-create time and the
+# gum-based picker can't run. This script installs a sensible default toolset
+# non-interactively instead, by pre-seeding the selection files that
+# setup.sh reads and then running the relevant sections in --rerun mode.
+#
+# Override the defaults via containerEnv in devcontainer.json (or Codespaces
+# secrets/variables). Set a variable to an empty string to opt out of that
+# tier entirely:
+#
+#   SQUAREBOX_DC_AI       AI assistants     (default: claude)
+#   SQUAREBOX_DC_SDKS     language SDKs      (default: node)
+#   SQUAREBOX_DC_EDITORS  text editors       (default: none)
+#   SQUAREBOX_DC_TUIS     TUI tools          (default: none)
+#
+# Values are comma-separated and use the same keys as sqrbx-setup, e.g.
+# SQUAREBOX_DC_AI="claude,codex" or SQUAREBOX_DC_SDKS="node,python".
+set -euo pipefail
+
+CONFIG_DIR=/workspace/.squarebox
+SETUP=/usr/local/lib/squarebox/setup.sh
+
+mkdir -p "$CONFIG_DIR"
+
+# Default toolset. Use ${VAR-default} (not :-) so an explicitly empty value
+# opts out, while an unset value falls back to the default.
+AI=${SQUAREBOX_DC_AI-claude}
+SDKS=${SQUAREBOX_DC_SDKS-node}
+EDITORS=${SQUAREBOX_DC_EDITORS-}
+TUIS=${SQUAREBOX_DC_TUIS-}
+
+sections=()
+
+# seed <config-file> <value> <section>
+# Writes the selection file only if absent, so a user's prior sqrbx-setup
+# choices win on rebuild. Queues the section for install when the value is
+# non-empty (whether freshly seeded or already present).
+seed() {
+	local file=$1 value=$2 section=$3
+	[ -z "$value" ] && return 0
+	[ -f "$CONFIG_DIR/$file" ] || printf '%s\n' "$value" > "$CONFIG_DIR/$file"
+	sections+=("$section")
+}
+
+seed ai-tool "$AI"      ai
+seed sdks    "$SDKS"    sdks
+seed editors "$EDITORS" editors
+seed tuis    "$TUIS"    tuis
+
+if [ ${#sections[@]} -eq 0 ]; then
+	echo "squarebox: no default tools selected; run 'sqrbx-setup' to configure."
+	exit 0
+fi
+
+echo "squarebox: installing default toolset (${sections[*]})..."
+"$SETUP" --rerun "${sections[@]}"

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -318,14 +318,21 @@ suite_devcontainer() {
 	# 8.1 valid JSON
 	run_test "8.1 devcontainer.json is valid JSON" jq empty "$dc"
 
-	# 8.3 workspace folder
-	run_test_grep "8.3 workspaceFolder is /workspace" "/workspace" jq -r '.workspaceFolder' "$dc"
+	# 8.3 workspace folder — must resolve to the cloned repo under /workspaces,
+	# not the image's empty /workspace dir (Codespaces/Dev Containers convention)
+	run_test_grep "8.3 workspaceFolder is the cloned repo" "/workspaces/" jq -r '.workspaceFolder' "$dc"
 
 	# 8.4 user is dev
 	run_test_grep "8.4 remoteUser is dev" "dev" jq -r '.remoteUser' "$dc"
 
 	# 8.5 DEVCONTAINER=1
 	run_test_grep "8.5 DEVCONTAINER env var set" "1" jq -r '.containerEnv.DEVCONTAINER' "$dc"
+
+	# 8.6 postCreateCommand installs a default toolset non-interactively
+	run_test_grep "8.6 postCreateCommand is set" "devcontainer-postcreate" jq -r '.postCreateCommand' "$dc"
+
+	# 8.7 post-create script exists and is syntactically valid bash
+	run_test "8.7 devcontainer-postcreate.sh parses" bash -n scripts/devcontainer-postcreate.sh
 }
 
 # ── Suite: setup-rerun ───────────────────────────────────────────────────


### PR DESCRIPTION
## What & why

squarebox already shipped a `.devcontainer/devcontainer.json`, but in GitHub Codespaces / Dev Containers it built and started into a **broken, bare state**. Two concrete issues, both fixed here:

### 1. The editor opened an empty folder
`workspaceFolder` was set to `/workspace` — the image's empty dir created in the Dockerfile — while Codespaces always clones the repo to `/workspaces/<repo>` (a mount you can't override). So you'd open the Codespace and find an empty folder, with your code elsewhere.

**Fix:** point `workspaceFolder` at `/workspaces/${localWorkspaceFolderBasename}`, the Codespaces/Dev Containers convention. This also *structurally decouples* the selection store (`/workspace/.squarebox`) from the source tree (`/workspaces/<repo>`) — they're now distinct dirs, so selection state stays out of the user's repo.

### 2. No tools were ever installed
The interactive first-run wizard is skipped under `DEVCONTAINER=1` (there's no TTY at create time and the gum picker can't run), and nothing replaced it — so a Codespace booted with only the base CLI tier: no AI assistant, no SDKs, no editors.

**Fix:** add a `postCreateCommand` → `scripts/devcontainer-postcreate.sh`, which pre-seeds the selection files `setup.sh` reads and runs the relevant sections **non-interactively**. Defaults to **Claude Code + Node.js** (lightweight, immediately useful). Overridable via container env vars, with an empty string opting a tier out:

| Variable | Default | Selects |
|----------|---------|---------|
| `SQUAREBOX_DC_AI` | `claude` | `claude,copilot,gemini,codex,opencode,pi` |
| `SQUAREBOX_DC_SDKS` | `node` | `node,python,go,dotnet,rust` |
| `SQUAREBOX_DC_EDITORS` | _(none)_ | `micro,edit,fresh,nvim` |
| `SQUAREBOX_DC_TUIS` | _(none)_ | `lazygit,gh-dash,yazi` |

Pre-existing selections (from a prior `sqrbx-setup`) are preserved rather than overwritten.

## Scope / safety
- **Only affects the devcontainer / Codespaces path.** The `docker run` + `install.sh` flow doesn't read `devcontainer.json` and is untouched.
- `devcontainer.json` stays strict JSON (no comments) so the `jq empty` CI check keeps passing.
- The post-create script reuses the existing `setup.sh --rerun` non-interactive path — no installer logic is duplicated.

## Tests
- Updated the e2e devcontainer suite: 8.3 now asserts `/workspaces/`, plus new 8.6 (`postCreateCommand` is set) and 8.7 (script parses). All 6 pass locally.
- Validated `jq empty` on the JSON, `bash -n` on both scripts, and dry-ran the seeding logic across default / override / opt-out / pre-existing-config cases.

https://claude.ai/code/session_01HBRYu6B5ifQ8S2Rxi38M11

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBRYu6B5ifQ8S2Rxi38M11)_