### PR TITLE
feat: add ttt to the text editor options

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ The `install.sh` script automates initial setup (clone, build, create container,
 1. **Git identity** — name and email (skipped if already configured)
 2. **GitHub CLI auth** — persisted to `/workspace/.squarebox/gh` across rebuilds
 3. **AI coding assistant** — Claude Code, GitHub Copilot CLI, Google Gemini CLI, OpenAI Codex CLI, OpenCode (any combination)
-4. **Text editors** — micro, edit (Microsoft), fresh, nvim (nano is always available)
+4. **Text editors** — micro, edit (Microsoft), fresh, ttt, nvim (nano is always available)
 5. **TUI tools** — lazygit, gh-dash, yazi (any combination)
 6. **Terminal multiplexers** — tmux, zellij
 7. **SDKs** — Node.js, Python, Go, .NET, Rust (all installed and managed by [mise](https://github.com/jdx/mise) via `~/.config/mise/config.toml`)

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Nano is always available as the default editor.
 | [micro](https://github.com/micro-editor/micro) | Go | Modern, intuitive terminal editor |
 | [edit](https://github.com/microsoft/edit) | Rust | Terminal text editor (Microsoft) |
 | [fresh](https://github.com/sinelaw/fresh) | Rust | Modern terminal text editor |
+| [ttt](https://github.com/eugenioenko/ttt) | Go | Terminal text editor IDE, single binary, zero config |
 | [helix](https://github.com/helix-editor/helix) | Rust | Modal editor (Kakoune-inspired) - *coming soon* |
 | [nvim](https://github.com/neovim/neovim) | C/Lua | Neovim |
 
@@ -350,7 +351,7 @@ First-run selections add to that:
 | Pi Coding Agent | ~50 MB |
 | lazygit / gh-dash / yazi | ~10 / ~10 / ~10 MB |
 | micro / edit | ~12 / ~7 MB |
-| fresh / nvim | ~10 / ~45 MB |
+| fresh / ttt / nvim | ~10 / ~8 / ~45 MB |
 | Node.js | ~90 MB |
 | Python | ~50 MB |
 | Go | ~500 MB |

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -173,7 +173,7 @@ suite_setup_editors() {
 	# Pre-seed selections in /workspace/.squarebox/
 	mkdir -p /workspace/.squarebox
 	echo "opencode,pi" > /workspace/.squarebox/ai-tool
-	echo "micro,edit,fresh,nvim" > /workspace/.squarebox/editors
+	echo "micro,edit,fresh,ttt,nvim" > /workspace/.squarebox/editors
 	echo "lazygit,gh-dash,yazi" > /workspace/.squarebox/tuis
 	echo "tmux,zellij" > /workspace/.squarebox/multiplexer
 	echo "node,go" > /workspace/.squarebox/sdks
@@ -207,7 +207,8 @@ suite_setup_editors() {
 	run_test "3.7b micro installed" command -v micro
 	run_test "3.7c edit installed" command -v edit
 	run_test "3.7d fresh installed" command -v fresh
-	run_test "3.7e nvim installed" command -v nvim
+	run_test "3.7e ttt installed" command -v ttt
+	run_test "3.7f nvim installed" command -v nvim
 
 	# 3.7f-h TUI tools installed
 	run_test "3.7f lazygit installed" command -v lazygit

--- a/scripts/lib/tools.yaml
+++ b/scripts/lib/tools.yaml
@@ -197,6 +197,15 @@ tools:
     dest: user
     group: setup
 
+  ttt:
+    repo: eugenioenko/ttt
+    version_prefix: v
+    artifact: ttt-linux-{goarch}
+    method: binary
+    binaries: ttt
+    dest: user
+    group: setup
+
   zellij:
     repo: zellij-org/zellij
     version_prefix: v

--- a/scripts/squarebox-setup.sh
+++ b/scripts/squarebox-setup.sh
@@ -32,7 +32,7 @@ usage() {
 	  git            Git identity (name, email)
 	  github         GitHub CLI authentication
 	  ai             AI coding assistants (claude, copilot, gemini, codex, opencode, pi)
-	  editors        Text editors (micro, edit, fresh, nvim)
+	  editors        Text editors (micro, edit, fresh, ttt, nvim)
 	  tuis           TUI tools (lazygit, gh-dash, yazi)
 	  multiplexers   Terminal multiplexers (tmux, zellij)
 	  sdks           SDKs (node, python, go, dotnet, rust)

--- a/scripts/squarebox-update.sh
+++ b/scripts/squarebox-update.sh
@@ -134,6 +134,7 @@ glow_current() { glow --version 2>/dev/null | head -1 | grep -oP '[\d.]+' | head
 gum_current() { gum --version 2>/dev/null | head -1 | grep -oP '[\d.]+' | head -1 || echo "not installed"; }
 micro_current() { micro --version 2>/dev/null | head -1 | awk '{print $2}' || echo "not installed"; }
 fresh_current() { fresh --version 2>/dev/null | grep -oP '[\d.]+' | head -1 || echo "not installed"; }
+ttt_current() { ttt --version 2>/dev/null | grep -oP '[\d.]+' | head -1 || echo "not installed"; }
 edit_current() { edit --version 2>/dev/null | grep -oP '[\d.]+' | head -1 || echo "not installed"; }
 helix_current() { hx --version 2>/dev/null | head -1 | awk '{print $2}' || echo "not installed"; }
 nvim_current() { nvim --version 2>/dev/null | head -1 | awk '{print $2}' | sed 's/^v//' || echo "not installed"; }
@@ -161,8 +162,8 @@ tool_latest() {
 
 # ── Tool registry ──────────────────────────────────────────────────────
 
-TOOLS=(delta yq lazygit xh yazi starship ghdash glow gum just difftastic mise micro fresh edit helix nvim opencode zellij)
-TOOL_DISPLAY_NAMES=(delta yq lazygit xh yazi starship gh-dash glow gum just difftastic mise micro fresh edit helix nvim opencode zellij)
+TOOLS=(delta yq lazygit xh yazi starship ghdash glow gum just difftastic mise micro fresh edit helix nvim ttt opencode zellij)
+TOOL_DISPLAY_NAMES=(delta yq lazygit xh yazi starship gh-dash glow gum just difftastic mise micro fresh edit helix nvim ttt opencode zellij)
 
 # Map display names to tools.yaml names (ghdash → gh-dash)
 yaml_name() {
@@ -186,7 +187,7 @@ usage() {
 	  sqrbx-update --help       Show this help
 
 	${BOLD}Tools:${RESET}
-	  delta, yq, lazygit, xh, yazi, starship, gh-dash, glow, gum, just, difftastic, mise, micro, fresh, edit, helix, nvim, opencode, zellij
+	  delta, yq, lazygit, xh, yazi, starship, gh-dash, glow, gum, just, difftastic, mise, micro, fresh, edit, helix, nvim, ttt, opencode, zellij
 
 	EOF
 }

--- a/setup.sh
+++ b/setup.sh
@@ -510,6 +510,7 @@ if $INTERACTIVE; then
 				micro) gum_selected="${gum_selected:+$gum_selected,}micro" ;;
 				edit)  gum_selected="${gum_selected:+$gum_selected,}edit" ;;
 				fresh) gum_selected="${gum_selected:+$gum_selected,}fresh" ;;
+				ttt)   gum_selected="${gum_selected:+$gum_selected,}ttt" ;;
 				nvim)  gum_selected="${gum_selected:+$gum_selected,}nvim" ;;
 			esac
 		done
@@ -517,7 +518,7 @@ if $INTERACTIVE; then
 		gum_args=(--no-limit --header "Select text editors to install:")
 		[ -n "$gum_selected" ] && gum_args+=(--selected "$gum_selected")
 		selected=$(gum choose "${gum_args[@]}" \
-			"micro" "edit" "fresh" "nvim") || true
+			"micro" "edit" "fresh" "ttt" "nvim") || true
 		editor_list=""
 		while IFS= read -r line; do
 			[ -z "$line" ] && continue
@@ -526,12 +527,13 @@ if $INTERACTIVE; then
 	else
 		echo "Select text editors to install (comma-separated, or 'all', or press Enter to skip):"
 		echo "  Nano is always available as the default editor."
-		for ed_item in "1:micro:micro" "2:edit:edit" "3:fresh:fresh" "4:nvim:nvim"; do
+		for ed_item in "1:micro:micro" "2:edit:edit" "3:fresh:fresh" "4:ttt:ttt" "5:nvim:nvim"; do
 			num="${ed_item%%:*}"; rest="${ed_item#*:}"; key="${rest%%:*}"; label="${rest#*:}"
 			case "$key" in
 				micro) desc="modern, intuitive terminal editor" ;;
 				edit)  desc="terminal text editor (Microsoft)" ;;
 				fresh) desc="modern terminal text editor" ;;
+				ttt)   desc="terminal text editor IDE, single binary" ;;
 				nvim)  desc="Neovim" ;;
 			esac
 			if [[ ",$editor_prev," == *",${key},"* ]]; then
@@ -540,20 +542,21 @@ if $INTERACTIVE; then
 				echo "  ${num}) ${label} — ${desc}"
 			fi
 		done
-		read -rp "Selection [1,2,3,4/all/skip]: " editor_selection
+		read -rp "Selection [1,2,3,4,5/all/skip]: " editor_selection
 		if [ -z "$editor_selection" ] && [ -n "$editor_prev" ]; then
 			editor_list="$editor_prev"
 		else
 			editor_list=""
 			if [ "$editor_selection" = "all" ]; then
-				editor_list="micro,edit,fresh,nvim"
+				editor_list="micro,edit,fresh,ttt,nvim"
 			elif [ -n "$editor_selection" ]; then
 				for item in $(echo "$editor_selection" | tr ',' ' '); do
 					case "$item" in
 						1) editor_list="${editor_list:+$editor_list,}micro" ;;
 						2) editor_list="${editor_list:+$editor_list,}edit" ;;
 						3) editor_list="${editor_list:+$editor_list,}fresh" ;;
-						4) editor_list="${editor_list:+$editor_list,}nvim" ;;
+						4) editor_list="${editor_list:+$editor_list,}ttt" ;;
+						5) editor_list="${editor_list:+$editor_list,}nvim" ;;
 					esac
 				done
 			fi
@@ -584,6 +587,11 @@ install_fresh() {
 	run_with_spinner "Installing Fresh..." sb_install fresh latest
 }
 
+install_ttt() {
+	if command -v ttt &>/dev/null; then echo "TTT already installed, skipping."; return 0; fi
+	run_with_spinner "Installing TTT..." sb_install ttt latest
+}
+
 install_nvim() {
 	if command -v nvim &>/dev/null; then echo "Neovim already installed, skipping."; return 0; fi
 	run_with_spinner "Installing Neovim..." sb_install nvim latest
@@ -595,6 +603,7 @@ for editor in $(echo "$editor_list" | tr ',' ' '); do
 		micro) install_micro && installed_editors+=("micro") || echo "Warning: Micro installation failed." ;;
 		edit) install_edit && installed_editors+=("edit") || echo "Warning: Edit installation failed." ;;
 		fresh) install_fresh && installed_editors+=("fresh") || echo "Warning: Fresh installation failed." ;;
+		ttt) install_ttt && installed_editors+=("ttt") || echo "Warning: TTT installation failed." ;;
 		nvim) install_nvim && installed_editors+=("nvim") || echo "Warning: Neovim installation failed." ;;
 	esac
 done


### PR DESCRIPTION
## Summary
Adds **ttt** ([eugenioenko/ttt](https://github.com/eugenioenko/ttt)) — a single-binary, zero-config terminal text editor IDE — as a selectable editor in first-run setup.

## Changes
- **`scripts/lib/tools.yaml`** — new `ttt` entry (`method: binary`, `artifact: ttt-linux-{goarch}`, `group: setup`)
- **`setup.sh`** — gum + numeric menus, `all` list, `install_ttt`, dispatch case
- **`scripts/squarebox-update.sh`** — `ttt_current()` + registered in `TOOLS`/help so `sqrbx-update` tracks it (install dispatch already generic)
- **`scripts/squarebox-setup.sh`** / **`CLAUDE.md`** / **`README.md`** — editor lists, tool table, size note (~8 MB)
- **`scripts/e2e-test.sh`** — seeded selection + `command -v ttt` assertion

## Notes
- `setup`-group tool → installs latest upstream at setup time, no checksum pinning (`update-versions.sh` untouched).
- Verified the resolved download URL returns HTTP 200 and the yaml entry parses; all modified shell scripts pass `bash -n`.
- ttt's exact `--version` string wasn't run-verified (download-and-exec blocked locally); from source it prints `ttt <version>`, which `ttt_current()`'s digit extraction handles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)