### PR TITLE
feat: enable fzf keybindings + bash-completion in bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	ripgrep \
 	bat \
 	fzf \
+	bash-completion \
 	nano \
 	zstd \
 	zoxide \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,14 @@ FROM ubuntu:24.04
 
 # 1. Base Packages & Rust CLI Tools (consolidated, slimmed)
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# The Ubuntu base image strips /usr/share/doc/* (dpkg.cfg.d/excludes), but fzf
+# ships its shell keybindings ONLY under /usr/share/doc/fzf/examples/. Re-include
+# that one file (must be set BEFORE fzf is unpacked below) so the Ctrl+R/Ctrl+T/
+# Alt+C bindings sourced from bashrc actually exist. The ** completion lives under
+# /usr/share/bash-completion/ and is unaffected.
+RUN printf 'path-include=/usr/share/doc/fzf/examples/key-bindings.bash\n' \
+		> /etc/dpkg/dpkg.cfg.d/zz-squarebox-fzf \
+	&& apt-get update && apt-get install -y --no-install-recommends \
 	git \
 	curl \
 	unzip \

--- a/dotfiles/bashrc
+++ b/dotfiles/bashrc
@@ -21,10 +21,12 @@ eval "$(starship init bash)"
 eval "$(zoxide init bash --cmd cd)"
 # bash-completion (git subcommands, flags, etc.)
 [ -f /usr/share/bash-completion/bash_completion ] && source /usr/share/bash-completion/bash_completion
-# fzf keybindings + completion (Ctrl+R history, Ctrl+T files, Alt+C cd).
-# Ubuntu's apt fzf ships these scripts but does not auto-source them.
+# fzf keybindings + completion (Ctrl+R history, Ctrl+T files, Alt+C cd, ** trigger).
+# Ubuntu's apt fzf ships the keybindings under doc/examples but does not auto-source
+# them; the ** completion lives in the bash-completion dir (lazy-loaded only on first
+# fzf<TAB>), so source it explicitly to wire the trigger up at shell startup.
 [ -f /usr/share/doc/fzf/examples/key-bindings.bash ] && source /usr/share/doc/fzf/examples/key-bindings.bash
-[ -f /usr/share/doc/fzf/examples/completion.bash  ] && source /usr/share/doc/fzf/examples/completion.bash
+[ -f /usr/share/bash-completion/completions/fzf ] && source /usr/share/bash-completion/completions/fzf
 alias ls='eza --icons'
 alias ll='eza -la --icons'
 alias lsa='ls -a'

--- a/dotfiles/bashrc
+++ b/dotfiles/bashrc
@@ -19,6 +19,12 @@ shopt -s checkwinsize
 # squarebox additions
 eval "$(starship init bash)"
 eval "$(zoxide init bash --cmd cd)"
+# bash-completion (git subcommands, flags, etc.)
+[ -f /usr/share/bash-completion/bash_completion ] && source /usr/share/bash-completion/bash_completion
+# fzf keybindings + completion (Ctrl+R history, Ctrl+T files, Alt+C cd).
+# Ubuntu's apt fzf ships these scripts but does not auto-source them.
+[ -f /usr/share/doc/fzf/examples/key-bindings.bash ] && source /usr/share/doc/fzf/examples/key-bindings.bash
+[ -f /usr/share/doc/fzf/examples/completion.bash  ] && source /usr/share/doc/fzf/examples/completion.bash
 alias ls='eza --icons'
 alias ll='eza -la --icons'
 alias lsa='ls -a'


### PR DESCRIPTION
## What

The apt `fzf` in the image ships the keybinding/completion scripts but never sources them, so the fuzzy keyboard shortcuts were dead. This sources them (plus `bash-completion`) from the managed `bashrc` and adds the `bash-completion` package to the Dockerfile apt block.

## Why

Reported by a user SSH'd into a squarebox instance from Blink Shell on iOS — wanted fzf/zoxide keyboard shortcuts. They were never wired up.

## Effect

- **Ctrl+R** — fuzzy history search
- **Ctrl+T** — fuzzy file picker (pastes path)
- **Alt+C** — fuzzy `cd` into subdir
- richer tab-completion (git subcommands, flags, etc.)

zoxide's interactive `cdi` already worked and complements Alt+C (useful on mobile keyboards where Meta is awkward).

## Notes

- All `source` lines are guarded with `[ -f ... ]` so they no-op if the paths ever move.
- Existing users pick this up after a `git pull` on the host + rebuild (bashrc is bind-mounted read-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)