### PR TITLE
feat: add sqrbx-help command and surface it in the MOTD

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,10 @@ Valid sections: `git`, `github`, `ai`, `editors`, `tuis`, `multiplexers`, `sdks`
 
 Run `source ~/.bashrc` after setup to pick up new aliases and PATH changes in the current shell.
 
+### Getting Help
+
+`sqrbx-help` prints a one-screen overview of the `sqrbx-*` commands plus the fzf (`Ctrl+R`/`Ctrl+T`/`Alt+C`/`**<Tab>`) and zoxide (`cd`/`cdi`) keyboard shortcuts. The script (`scripts/squarebox-help.sh`) guards each command row with `command -v`, so it only lists tools actually installed. The MOTD (`motd.sh`) points to it on every shell start.
+
 ## Updating Tool Versions
 
 ```bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -140,6 +140,7 @@ COPY setup.sh /usr/local/lib/squarebox/setup.sh
 COPY scripts/squarebox-update.sh /usr/local/bin/sqrbx-update
 COPY scripts/squarebox-setup.sh /usr/local/bin/sqrbx-setup
 COPY scripts/sqrbx-learn /usr/local/bin/sqrbx-learn
+COPY scripts/squarebox-help.sh /usr/local/bin/sqrbx-help
 COPY scripts/squarebox-entrypoint.sh /usr/local/bin/squarebox-entrypoint
 COPY scripts/lib/tools.yaml /usr/local/lib/squarebox/tools.yaml
 COPY scripts/lib/tool-lib.sh /usr/local/lib/squarebox/tool-lib.sh
@@ -148,6 +149,7 @@ RUN chmod +x /usr/local/lib/squarebox/setup.sh \
 	/usr/local/bin/sqrbx-update \
 	/usr/local/bin/sqrbx-setup \
 	/usr/local/bin/sqrbx-learn \
+	/usr/local/bin/sqrbx-help \
 	/usr/local/bin/squarebox-entrypoint
 
 RUN chown -R dev:dev /home/dev/.config /home/dev/.claude \

--- a/README.md
+++ b/README.md
@@ -334,6 +334,14 @@ to scale both the examples and the agent's coaching; you can change it later
 from the menu. Lessons render through `glow` when available so the markdown
 bodies display properly.
 
+Getting help
+------------
+
+Run `sqrbx-help` inside the container for a one-screen overview of the
+`sqrbx-*` commands plus the fzf (`Ctrl+R`/`Ctrl+T`/`Alt+C`/`**<Tab>`) and
+zoxide (`cd`/`cdi`) keyboard shortcuts. The MOTD points to it on every shell
+start.
+
 Reconfiguring
 -------------
 

--- a/motd.sh
+++ b/motd.sh
@@ -43,4 +43,7 @@ fi
 if [ -f "/workspace/.squarebox/learn" ] && grep -qx "enabled" /workspace/.squarebox/learn 2>/dev/null; then
 	printf '\e[38;5;208m  ✦ sqrbx-learn\e[0m\e[38;5;245m — learn the toolkit hands-on with your AI agent\e[0m\n'
 fi
+
+# Help hint
+printf '\e[38;5;208m  ✦ sqrbx-help\e[0m\e[38;5;245m — commands and keyboard shortcuts\e[0m\n'
 echo

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -267,6 +267,14 @@ suite_setup_editors() {
 	run_test_grep "3.13d motd shows learn hint when enabled" "sqrbx-learn" bash /usr/local/lib/squarebox/motd.sh
 	run_test_grep "3.13e help documents hands-on agent mode" "hands-on" sqrbx-learn --help
 	run_test "3.13f unknown lesson arg errors" bash -c '! sqrbx-learn __no_such_tool__ 2>/dev/null'
+
+	# 3.14 sqrbx-help: installed, lists commands + fzf/zoxide shortcuts,
+	# and the motd surfaces the hint
+	run_test "3.14a sqrbx-help installed" command -v sqrbx-help
+	run_test_grep "3.14b sqrbx-help lists sqrbx-setup" "sqrbx-setup" sqrbx-help
+	run_test_grep "3.14c sqrbx-help documents fzf shortcuts" "Ctrl+R" sqrbx-help
+	run_test_grep "3.14d sqrbx-help documents zoxide cd" "zoxide" sqrbx-help
+	run_test_grep "3.14e motd shows help hint" "sqrbx-help" bash /usr/local/lib/squarebox/motd.sh
 }
 
 # ── Suite: update ────────────────────────────────────────────────────────

--- a/scripts/squarebox-help.sh
+++ b/scripts/squarebox-help.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# sqrbx-help — list squarebox commands and handy keyboard shortcuts.
+#
+# Usage:
+#   sqrbx-help        Show this overview
+
+# Colors (ANSI-C quoting embeds real ESC bytes so heredocs render them)
+BOLD=$'\033[1m'
+DIM=$'\033[2m'
+ORANGE=$'\033[38;5;208m'
+CYAN=$'\033[0;36m'
+RESET=$'\033[0m'
+
+# Print a command row only if the command is on PATH.
+cmd_row() {
+	local name="$1" desc="$2"
+	if command -v "$name" >/dev/null 2>&1; then
+		printf "  ${CYAN}%-14s${RESET} %s\n" "$name" "$desc"
+	fi
+}
+
+cat <<-EOF
+
+	${ORANGE}${BOLD}🟧📦 squarebox${RESET} — containerized dev environment
+
+	${BOLD}Commands:${RESET}
+EOF
+
+cmd_row sqrbx-setup  "Re-run the setup wizard to add/change tools (--list, --help)"
+cmd_row sqrbx-update "Update installed tool binaries in-place from upstream"
+cmd_row sqrbx-learn  "Learn the toolkit hands-on with your AI agent"
+cmd_row sqrbx-help   "Show this overview"
+
+cat <<-EOF
+
+	${BOLD}Keyboard shortcuts:${RESET}
+	  ${CYAN}Ctrl+R${RESET}         Fuzzy-search command history (fzf)
+	  ${CYAN}Ctrl+T${RESET}         Fuzzy-find a file/dir, paste path on the command line (fzf)
+	  ${CYAN}Alt+C${RESET}          Fuzzy-find a subdirectory and cd into it (fzf)
+	  ${CYAN}**<Tab>${RESET}        Fuzzy-complete the current word, e.g. \`vim **<Tab>\` (fzf)
+
+	${BOLD}Navigation:${RESET}
+	  ${CYAN}cd <part>${RESET}      Jump to a frecent directory by partial name (zoxide)
+	  ${CYAN}cdi <part>${RESET}     Same, but pick interactively from matches (zoxide)
+	  ${CYAN}.. ... ....${RESET}    Up one / two / three directories
+
+	${BOLD}Aliases:${RESET}
+	  ${CYAN}ls ll lt${RESET}       Listings via eza (icons, tree, git)
+	  ${CYAN}cat${RESET}            Syntax-highlighted output via bat
+	  ${CYAN}ff / eff${RESET}       fzf file picker / open the picked file in \$EDITOR
+	  ${CYAN}g gcm gcam${RESET}     git / git commit -m / git commit -a -m
+
+	${DIM}Docs: https://github.com/SquareWaveSystems/squarebox${RESET}
+
+EOF


### PR DESCRIPTION
## Summary
- New `sqrbx-help` command: one-screen overview of the `sqrbx-*` commands plus fzf (`Ctrl+R`/`Ctrl+T`/`Alt+C`/`**<Tab>`) and zoxide (`cd`/`cdi`) keyboard shortcuts
- Command rows are guarded by `command -v`, so only installed tools show
- Hinted in the MOTD on every shell start

## Changes
- `scripts/squarebox-help.sh` (new) — the command; ANSI-C-quoted colors so heredoc escapes render
- `Dockerfile` — `COPY` to `/usr/local/bin/sqrbx-help` + `chmod +x`
- `motd.sh` — `✦ sqrbx-help` hint line
- `scripts/e2e-test.sh` — tests 3.14a–e (installed, lists commands, fzf/zoxide docs, motd hint)
- `README.md` / `CLAUDE.md` — "Getting help" docs

## Test plan
- [x] `bash -n` syntax check passes
- [x] Renders correctly; absent commands are hidden via `command -v`
- [x] MOTD shows the hint
- [ ] CI build + e2e suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)