### PR TITLE
feat: use default zoxide z/zi instead of overloading cd

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ Run `source ~/.bashrc` after setup to pick up new aliases and PATH changes in th
 
 ### Getting Help
 
-`sqrbx-help` prints a one-screen overview of the `sqrbx-*` commands plus the fzf (`Ctrl+R`/`Ctrl+T`/`Alt+C`/`**<Tab>`) and zoxide (`cd`/`cdi`) keyboard shortcuts. The script (`scripts/squarebox-help.sh`) guards each command row with `command -v`, so it only lists tools actually installed. The MOTD (`motd.sh`) points to it on every shell start.
+`sqrbx-help` prints a one-screen overview of the `sqrbx-*` commands plus the fzf (`Ctrl+R`/`Ctrl+T`/`Alt+C`/`**<Tab>`) and zoxide (`z`/`zi`) keyboard shortcuts. The script (`scripts/squarebox-help.sh`) guards each command row with `command -v`, so it only lists tools actually installed. The MOTD (`motd.sh`) points to it on every shell start.
 
 ## Updating Tool Versions
 

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ Getting help
 
 Run `sqrbx-help` inside the container for a one-screen overview of the
 `sqrbx-*` commands plus the fzf (`Ctrl+R`/`Ctrl+T`/`Alt+C`/`**<Tab>`) and
-zoxide (`cd`/`cdi`) keyboard shortcuts. The MOTD points to it on every shell
+zoxide (`z`/`zi`) keyboard shortcuts. The MOTD points to it on every shell
 start.
 
 Reconfiguring

--- a/dotfiles/bashrc
+++ b/dotfiles/bashrc
@@ -19,7 +19,7 @@ shopt -s checkwinsize
 
 # squarebox additions
 eval "$(starship init bash)"
-eval "$(zoxide init bash --cmd cd)"
+eval "$(zoxide init bash)"
 # bash-completion (git subcommands, flags, etc.)
 [ -f /usr/share/bash-completion/bash_completion ] && source /usr/share/bash-completion/bash_completion
 # fzf keybindings + completion (Ctrl+R history, Ctrl+T files, Alt+C cd, ** trigger).

--- a/scripts/sqrbx-learn
+++ b/scripts/sqrbx-learn
@@ -530,13 +530,14 @@ jumps to the most frecent directory that matches "foo". `autojump` (2009) had
 a similar idea but was slower.
 
 Ajeet D'Souza wrote `zoxide` in 2020 as a faster, cross-shell implementation.
-squarebox initialises zoxide in your shell and aliases it to `cd` — so every
-`cd` you run is also training it.
+squarebox initialises zoxide in your shell as `z` (with `zi` for the interactive
+picker), leaving the plain `cd` builtin untouched. Every `cd` you run still
+trains the database.
 
 **Key concepts:**
 • Every directory you `cd` into is added to the frecency database
-• `cd foo` — jump to the highest-frecency match for "foo"
-• `cd foo bar` — match a path containing both "foo" and "bar"
+• `z foo` — jump to the highest-frecency match for "foo"
+• `z foo bar` — match a path containing both "foo" and "bar"
 • `zi` — interactive picker (uses fzf) — browse the database
 • `zoxide query --list` — see your full frecency database
 • It gets smarter the more you use it
@@ -550,7 +551,7 @@ EOF
 	case "$sl" in
 		beginner)
 			echo "  cd /workspace          # normal cd also trains zoxide"
-			echo "  cd workspace           # jump to any frecent dir matching 'workspace'"
+			echo "  z workspace            # jump to any frecent dir matching 'workspace'"
 			;;
 		intermediate)
 			echo "  zi                     # interactive picker (needs fzf)"
@@ -559,8 +560,8 @@ EOF
 		expert)
 			echo "  zoxide query --list --score   # show with frecency scores"
 			echo "  zoxide remove /old/path       # remove a stale entry"
-			echo "  # zoxide also works with z and zi as aliases if preferred:"
-			echo "  # eval \"\$(zoxide init bash --cmd z)\""
+			echo "  # prefer to overload cd itself? re-init with --cmd cd:"
+			echo "  # eval \"\$(zoxide init bash --cmd cd)\""
 			;;
 	esac
 	echo
@@ -1273,7 +1274,7 @@ pair programming where they hold the keyboard.
 - fd over find — simpler syntax, sane defaults
 - bat over cat — syntax highlighting (already aliased to `cat`)
 - eza over ls — icons and git status (already aliased to `ls`)
-- zoxide over cd — frecency jumps (already aliased to `cd`)
+- zoxide over cd — frecency jumps (use `z <part>` / `zi` to pick)
 - fzf — fuzzy-pick anything (Ctrl-T files, Ctrl-R history, Alt-C dirs)
 - delta — syntax-highlighted git diffs (git's default pager here)
 - difft (difftastic) — structural, syntax-aware diffs
@@ -1325,7 +1326,7 @@ resolve_lesson_id() {
 		find)             echo "fd_vs_find"      ;;
 		cat)              echo "bat_vs_cat"      ;;
 		ls)               echo "eza_vs_ls"       ;;
-		cd)               echo "zoxide_cd"       ;;
+		cd|z)             echo "zoxide_cd"       ;;
 		difftastic)       echo "difftastic"      ;;
 		curl|http|httpie) echo "xh_http"         ;;
 		make)             echo "just_taskrunner" ;;

--- a/scripts/squarebox-help.sh
+++ b/scripts/squarebox-help.sh
@@ -42,8 +42,8 @@ cat <<-EOF
 	  ${CYAN}**<Tab>${RESET}        Fuzzy-complete the current word, e.g. \`vim **<Tab>\` (fzf)
 
 	${BOLD}Navigation:${RESET}
-	  ${CYAN}cd <part>${RESET}      Jump to a frecent directory by partial name (zoxide)
-	  ${CYAN}cdi <part>${RESET}     Same, but pick interactively from matches (zoxide)
+	  ${CYAN}z <part>${RESET}       Jump to a frecent directory by partial name (zoxide)
+	  ${CYAN}zi <part>${RESET}      Same, but pick interactively from matches (zoxide)
 	  ${CYAN}.. ... ....${RESET}    Up one / two / three directories
 
 	${BOLD}Aliases:${RESET}

--- a/setup.sh
+++ b/setup.sh
@@ -1405,7 +1405,7 @@ _install_zsh_inner() {
 		[ -f "$ZSH/oh-my-zsh.sh" ] && source "$ZSH/oh-my-zsh.sh"
 
 		eval "$(starship init zsh)"
-		eval "$(zoxide init zsh --cmd cd)"
+		eval "$(zoxide init zsh)"
 		alias ls='eza --icons'
 		alias ll='eza -la --icons'
 		alias lsa='ls -a'
@@ -1483,7 +1483,7 @@ _install_fish_inner() {
 		status is-interactive; or return
 
 		starship init fish | source
-		zoxide init fish --cmd cd | source
+		zoxide init fish | source
 
 		alias ls='eza --icons'
 		alias ll='eza -la --icons'


### PR DESCRIPTION
## What

Switches squarebox to omarchy's zoxide convention: init zoxide with its **default** commands — `z` to jump, `zi` for the interactive fzf picker — and leave the plain `cd` builtin untouched, instead of remapping `cd`/`cdi` via `--cmd cd`.

`cd` still trains the frecency database; you just keep the dumb builtin `cd` and get `z`/`zi` the way users coming from omarchy (or upstream zoxide docs) expect.

## Why

`cdi` worked but `z`/`zi` didn't, because `--cmd cd` renames zoxide's default commands. omarchy uses the plain `eval "$(zoxide init bash)"`. This aligns the two.

## Changes

- `dotfiles/bashrc`, `setup.sh` (zsh + fish) — drop `--cmd cd`
- `scripts/squarebox-help.sh` — navigation rows now show `z` / `zi`
- `scripts/sqrbx-learn` — zoxide lesson body, try-it examples, MOTD agent hint, and `z` deep-link alias
- `README.md`, `CLAUDE.md` — doc references `z`/`zi`

E2e greps (`zoxide init`, `zoxide` in `sqrbx-help`) still match — no test changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)