### PR TITLE
feat: bake squarebox version into the image and show it in the MOTD

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -418,6 +418,7 @@ jobs:
           {
             echo "tags=${tags}"
             echo "prerelease=${prerelease}"
+            echo "version=${ref}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
@@ -434,6 +435,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          build-args: |
+            SQUAREBOX_VERSION=${{ steps.meta.outputs.version }}
           # Reuse the layer caches the build-amd64 / build-arm64 jobs populated.
           cache-from: |
             type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -166,6 +166,14 @@ RUN chmod +x /usr/local/lib/squarebox/setup.sh \
 RUN chown -R dev:dev /home/dev/.config /home/dev/.claude \
 	&& mkdir -p /workspace && chown dev:dev /workspace
 
+# squarebox release version, baked at build time so the MOTD can surface it.
+# Defaults to "dev" for local/untagged builds; install.sh passes `git describe`
+# and the GHCR publish workflow passes the release tag. Declared this late so a
+# version bump only invalidates the trailing layers, not the whole tool stack.
+ARG SQUAREBOX_VERSION=dev
+RUN printf '%s\n' "$SQUAREBOX_VERSION" > /usr/local/lib/squarebox/VERSION
+LABEL org.opencontainers.image.version="$SQUAREBOX_VERSION"
+
 # The container starts as root so the entrypoint can honour PUID/PGID, then
 # drops to `dev` via setpriv. With the default 1000:1000 this is a no-op and
 # the running process is `dev` — identical to a plain `USER dev` image. PUID/

--- a/install.ps1
+++ b/install.ps1
@@ -113,13 +113,16 @@ if ($Edge) {
 }
 
 # --- Build ---
+# Stamp the image with the checked-out version so the MOTD can show it.
+$SquareboxVersion = (& git -C $InstallDir describe --tags --always --dirty 2>$null)
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($SquareboxVersion)) { $SquareboxVersion = "dev" }
 Write-Host "Building image... " -NoNewline
 if ($Verbose) {
     Write-Host ""
-    & $Runtime build -t $ImageName $InstallDir
+    & $Runtime build --build-arg "SQUAREBOX_VERSION=$SquareboxVersion" -t $ImageName $InstallDir
     if ($LASTEXITCODE -ne 0) { Abort "$Runtime build failed." }
 } else {
-    $buildLog = & $Runtime build -t $ImageName $InstallDir 2>&1
+    $buildLog = & $Runtime build --build-arg "SQUAREBOX_VERSION=$SquareboxVersion" -t $ImageName $InstallDir 2>&1
     if ($LASTEXITCODE -ne 0) {
         Write-Host "FAILED" -ForegroundColor Red
         Write-Host ($buildLog -join "`n")

--- a/install.sh
+++ b/install.sh
@@ -165,12 +165,16 @@ _rc_tmp=""
 _create_log=""
 trap 'rm -f "$_build_log" "$_rc_tmp" "$_create_log" 2>/dev/null || true' EXIT
 if [ "$EDGE" = 1 ] || [ "$BUILD" = 1 ]; then
+	# Stamp the image with the checked-out version so the MOTD can show it.
+	# git describe gives the tag for a release checkout (e.g. v0.6) or
+	# tag-distance-commit for edge/main (e.g. v0.6-12-gabc123); falls back to dev.
+	SQUAREBOX_VERSION=$(git -C "$INSTALL_DIR" describe --tags --always --dirty 2>/dev/null || echo dev)
 	if [ "$VERBOSE" = 1 ]; then
 		echo "Building image..."
-		rt_cmd build -t "$IMAGE_NAME" "$INSTALL_DIR"
+		rt_cmd build --build-arg "SQUAREBOX_VERSION=$SQUAREBOX_VERSION" -t "$IMAGE_NAME" "$INSTALL_DIR"
 	else
 		printf "Building image... "
-		if rt_cmd build -t "$IMAGE_NAME" "$INSTALL_DIR" > "$_build_log" 2>&1; then
+		if rt_cmd build --build-arg "SQUAREBOX_VERSION=$SQUAREBOX_VERSION" -t "$IMAGE_NAME" "$INSTALL_DIR" > "$_build_log" 2>&1; then
 			echo "done"
 		else
 			echo "FAILED" >&2

--- a/motd.sh
+++ b/motd.sh
@@ -5,7 +5,15 @@
 printf '\e[1;38;5;208m'
 toilet -f smblock --metal "squarebox"
 printf '\e[0m'
-printf '\e[38;5;208m  🟧📦 You'\''re in the box.\e[0m\n'
+
+# squarebox version, baked into the image at build time (Dockerfile VERSION file).
+sqbx_ver=""
+[ -r /usr/local/lib/squarebox/VERSION ] && sqbx_ver=$(tr -d '[:space:]' < /usr/local/lib/squarebox/VERSION)
+if [ -n "$sqbx_ver" ]; then
+	printf '\e[38;5;208m  🟧📦 You'\''re in the box.\e[0m\e[38;5;245m  (%s)\e[0m\n' "$sqbx_ver"
+else
+	printf '\e[38;5;208m  🟧📦 You'\''re in the box.\e[0m\n'
+fi
 
 # Detect installed SDKs from config
 sdks=()

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -99,6 +99,12 @@ suite_shell() {
 	# 4.3 MOTD runs without error
 	run_test "4.3 motd.sh runs" /usr/local/lib/squarebox/motd.sh
 
+	# 4.4 squarebox version is baked in and surfaced by the MOTD
+	run_test "4.4 VERSION file present and non-empty" test -s /usr/local/lib/squarebox/VERSION
+	run_test_grep "4.5 motd shows the baked version" \
+		"$(cat /usr/local/lib/squarebox/VERSION)" \
+		bash /usr/local/lib/squarebox/motd.sh
+
 	# 4.4 image-managed scripts not seeded into /home/dev/ (named volume would
 	# pin them stale across rebuilds — keep this assertion to prevent regression).
 	run_test "4.4 setup.sh not in /home/dev" bash -c '! test -e /home/dev/setup.sh'


### PR DESCRIPTION
## What

The MOTD showed no squarebox version. This bakes the release version into the image at build time and surfaces it on every shell start:

```
🟧📦 You're in the box.  (v0.6)
```

## How

- **Dockerfile** — new `ARG SQUAREBOX_VERSION=dev` (declared late so a version bump only invalidates trailing layers), written to `/usr/local/lib/squarebox/VERSION`, plus an `org.opencontainers.image.version` OCI label.
- **motd.sh** — reads the VERSION file and prints it dimmed next to the banner; falls back to the old line when the file is absent/empty.
- **Version sources:**
  - GHCR publish workflow passes the release tag via `build-args` (`e2e.yml`).
  - `install.sh` / `install.ps1` pass `git describe --tags --always --dirty` for source/edge builds.
  - Defaults to `dev` for local untagged builds.
- **e2e** — asserts the VERSION file exists and the MOTD output contains it.

## Notes

The `squarebox:test` images CI builds for the test suites carry no build-arg, so they stamp `dev` — which is what the new e2e checks assert against. Real published images get the tag (e.g. `v0.6`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)