### PR TITLE
feat: multi-LLM interactive learn mode — coach, ask/explain, agent recap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -140,6 +140,7 @@ COPY setup.sh /usr/local/lib/squarebox/setup.sh
 COPY scripts/squarebox-update.sh /usr/local/bin/sqrbx-update
 COPY scripts/squarebox-setup.sh /usr/local/bin/sqrbx-setup
 COPY scripts/sqrbx-learn /usr/local/bin/sqrbx-learn
+COPY scripts/sqrbx-agent-tool-log /usr/local/bin/sqrbx-agent-tool-log
 COPY scripts/squarebox-help.sh /usr/local/bin/sqrbx-help
 COPY scripts/squarebox-entrypoint.sh /usr/local/bin/squarebox-entrypoint
 COPY scripts/squarebox-refresh-dotfiles.sh /usr/local/lib/squarebox/refresh-dotfiles.sh
@@ -160,6 +161,7 @@ RUN chmod +x /usr/local/lib/squarebox/setup.sh \
 	/usr/local/bin/sqrbx-update \
 	/usr/local/bin/sqrbx-setup \
 	/usr/local/bin/sqrbx-learn \
+	/usr/local/bin/sqrbx-agent-tool-log \
 	/usr/local/bin/sqrbx-help \
 	/usr/local/bin/squarebox-entrypoint
 

--- a/README.md
+++ b/README.md
@@ -318,16 +318,35 @@ history, why-it-exists, and skill-level-adapted "try it" examples.
 
     sqrbx-learn               # open the menu
     sqrbx-learn rg            # jump straight to a tool's lesson
+    sqrbx-learn ask "..."     # one-shot toolkit question to your AI CLI
+    sqrbx-learn explain '...' # explain a command flag-by-flag
+    sqrbx-learn recap         # review the commands your agent has been running
     sqrbx-learn --progress    # show what you've completed
     sqrbx-learn --reset       # wipe progress AND skill level
 
-The top menu entry, **Learn hands-on with your AI agent**, launches Claude
-Code in a coaching mode for the session: instead of doing the work for you,
-it explains each step, hands you the exact command and the reason for the
-tool choice, and asks you to run it yourself. Say "just do it" at any point
-to let it take over. It's injected via `--append-system-prompt`, so it's
-session-scoped and never touches your workspace's own `CLAUDE.md`. (Requires
-Claude Code; add it with `sqrbx-setup ai`.)
+The top menu entry, **Learn hands-on with your AI agent**, launches your
+configured AI CLI — Claude Code, OpenCode, Gemini CLI, or Codex CLI — in a
+coaching mode for the session: instead of doing the work for you, it explains
+each step, hands you the exact command and the reason for the tool choice,
+and asks you to run it yourself. Say "just do it" at any point to let it take
+over. Claude Code gets the coaching persona via `--append-system-prompt`; the
+others receive it as a session-opening instruction. Either way it's
+session-scoped and never touches your workspace's own `CLAUDE.md`/`AGENTS.md`.
+(No AI CLI yet? Add one with `sqrbx-setup ai`.)
+
+`ask` and `explain` use the same AI CLI non-interactively: `ask` answers a
+toolkit question with the exact command to run, and `explain` breaks down a
+command flag-by-flag (defaulting to the last one in your shell history) and
+suggests the modern squarebox equivalent when you fed it a legacy tool. Both
+run on your own agent auth and cost tokens, so they only fire on demand.
+
+`recap` reverses the direction — learn from what your agent does. After
+`sqrbx-learn recap --enable` registers a Claude Code `PostToolUse` hook, every
+squarebox toolkit command the agent runs while working is logged to
+`/workspace/.squarebox/agent-tool-log`. `sqrbx-learn recap` then shows
+per-tool counts with real examples from your own tasks, and can hand the
+recent log to your AI CLI for a debrief of what those commands actually did.
+`recap --disable` removes the hook.
 
 The first launch asks for a skill level (beginner / intermediate / expert)
 to scale both the examples and the agent's coaching; you can change it later

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -268,6 +268,22 @@ suite_setup_editors() {
 	run_test_grep "3.13e help documents hands-on agent mode" "hands-on" sqrbx-learn --help
 	run_test "3.13f unknown lesson arg errors" bash -c '! sqrbx-learn __no_such_tool__ 2>/dev/null'
 
+	# 3.13g-3.13m ask/explain/recap: the agent-tool-log hook is installed and
+	# records toolkit commands, recap summarizes them, and --enable/--disable
+	# manage the Claude Code PostToolUse hook. Nothing here invokes a real
+	# LLM: recap only offers its AI debrief on an interactive terminal.
+	run_test "3.13g sqrbx-agent-tool-log installed" command -v sqrbx-agent-tool-log
+	run_test "3.13h hook logs toolkit commands" bash -c \
+		'echo "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"rg -l TODO src/\"}}" | sqrbx-agent-tool-log && grep -q "|rg|rg -l TODO" /workspace/.squarebox/agent-tool-log'
+	run_test "3.13i hook ignores non-toolkit commands" bash -c \
+		'echo "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo hello\"}}" | sqrbx-agent-tool-log && ! grep -q "echo hello" /workspace/.squarebox/agent-tool-log'
+	run_test_grep "3.13j recap summarizes the agent log" "rg -l TODO" sqrbx-learn recap
+	run_test "3.13k recap --enable registers claude hook" bash -c \
+		'sqrbx-learn recap --enable >/dev/null && jq -e --arg c /usr/local/bin/sqrbx-agent-tool-log ".hooks.PostToolUse[]?.hooks[]? | select(.command == \$c)" ~/.claude/settings.json'
+	run_test "3.13l recap --disable removes claude hook" bash -c \
+		'sqrbx-learn recap --disable >/dev/null && ! jq -e --arg c /usr/local/bin/sqrbx-agent-tool-log ".hooks.PostToolUse[]?.hooks[]? | select(.command == \$c)" ~/.claude/settings.json'
+	run_test_grep "3.13m help documents ask/explain/recap" "recap" sqrbx-learn --help
+
 	# 3.14 sqrbx-help: installed, lists commands + fzf/zoxide shortcuts,
 	# and the motd surfaces the hint
 	run_test "3.14a sqrbx-help installed" command -v sqrbx-help

--- a/scripts/sqrbx-agent-tool-log
+++ b/scripts/sqrbx-agent-tool-log
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# sqrbx-agent-tool-log — Claude Code PostToolUse hook for squarebox learn mode.
+# Records which squarebox toolkit commands the AI agent runs while it works,
+# so `sqrbx-learn recap` can turn the agent's real usage into lessons.
+#
+# Wire-up (managed by `sqrbx-learn recap --enable/--disable`): registered
+# under hooks.PostToolUse with matcher "Bash" in ~/.claude/settings.json.
+# Claude Code pipes the tool-call JSON to stdin.
+#
+# Log format: <epoch>|<tool>|<command>  (one line per toolkit tool spotted;
+# the command may itself contain "|", so parse fields 1-2 and treat the rest
+# as the command).
+#
+# This hook must never get in the agent's way: no set -e, and it always
+# exits 0 — a logging failure is not worth breaking a work session over.
+
+set -uo pipefail
+
+LOG_FILE="/workspace/.squarebox/agent-tool-log"
+MAX_LINES=1000
+
+# Keep in sync with the lesson catalog in sqrbx-learn.
+TOOLKIT="rg fd bat eza delta difft yq xh just glow gum fzf zoxide gh lazygit yazi"
+
+main() {
+	command -v jq >/dev/null 2>&1 || return 0
+
+	local input tool_name cmd
+	input=$(cat) || return 0
+	tool_name=$(jq -r '.tool_name // empty' <<<"$input" 2>/dev/null) || return 0
+	[ "$tool_name" = "Bash" ] || return 0
+	cmd=$(jq -r '.tool_input.command // empty' <<<"$input" 2>/dev/null) || return 0
+	[ -n "$cmd" ] || return 0
+
+	# Flatten to one line and cap the length so the log stays greppable.
+	cmd=$(printf '%s' "$cmd" | tr '\n\t' '  ' | cut -c1-200)
+
+	# Log one entry per toolkit tool that appears in command position —
+	# start of string, or right after a separator (; | & (), pipe, or $(.
+	local tool matched=""
+	for tool in $TOOLKIT; do
+		if printf '%s' "$cmd" | grep -Eq "(^|[;|&(])[[:space:]]*${tool}([[:space:]]|\$)"; then
+			matched="${matched}${tool} "
+		fi
+	done
+	[ -n "$matched" ] || return 0
+
+	mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || return 0
+	local now; now=$(date +%s)
+	for tool in $matched; do
+		printf '%s|%s|%s\n' "$now" "$tool" "$cmd" >> "$LOG_FILE"
+	done
+
+	# Trim so the log never grows unbounded.
+	if [ "$(wc -l < "$LOG_FILE")" -gt "$MAX_LINES" ]; then
+		tail -n "$MAX_LINES" "$LOG_FILE" > "${LOG_FILE}.tmp" && mv "${LOG_FILE}.tmp" "$LOG_FILE"
+	fi
+	return 0
+}
+
+main
+exit 0

--- a/scripts/sqrbx-learn
+++ b/scripts/sqrbx-learn
@@ -5,6 +5,9 @@
 # Usage:
 #   sqrbx-learn            Open the menu (hands-on AI agent mode, or browse lessons)
 #   sqrbx-learn <tool>     Jump straight to a tool's lesson (e.g. sqrbx-learn rg)
+#   sqrbx-learn ask "..."  Ask your configured AI CLI a toolkit question (one-shot)
+#   sqrbx-learn explain    Explain a command flag-by-flag (given, or your last one)
+#   sqrbx-learn recap      Review the toolkit commands your AI agent has been running
 #   sqrbx-learn --progress Show your progress
 #   sqrbx-learn --reset    Reset all progress AND skill level
 #   sqrbx-learn --help     Show this help
@@ -15,6 +18,9 @@ set -euo pipefail
 
 PROGRESS_FILE="/workspace/.squarebox/learn-progress"
 SQUAREBOX_DIR="/workspace/.squarebox"
+AGENT_LOG="/workspace/.squarebox/agent-tool-log"
+CLAUDE_SETTINGS="${HOME}/.claude/settings.json"
+AGENT_LOG_HOOK="/usr/local/bin/sqrbx-agent-tool-log"
 
 # ── Required tool guard ──────────────────────────────────────────────────────
 # gum drives the interactive UI. Most invocations need it, but --help and
@@ -82,6 +88,64 @@ has_tool() {
 		*)
 			command -v "$tool" &>/dev/null ;;
 	esac
+}
+
+# ── Configured AI agent detection ────────────────────────────────────────────
+# Coach mode and the one-shot commands (ask/explain/recap) work with whichever
+# AI CLIs setup.sh installed. Binary presence is the source of truth (same
+# rationale as has_tool): /workspace/.squarebox/ai can go stale across
+# rebuilds, but `command -v` never lies.
+#
+# Not listed: copilot (github-copilot-cli suggests one-liners; it has no agent
+# session or print mode to inject a tutor prompt into) and pi (no documented
+# system-prompt or initial-prompt injection yet).
+
+AGENT_ORDER=(claude opencode gemini codex)
+
+agent_label() {
+	case "$1" in
+		claude)   echo "Claude Code"       ;;
+		opencode) echo "OpenCode"          ;;
+		gemini)   echo "Google Gemini CLI" ;;
+		codex)    echo "OpenAI Codex CLI"  ;;
+	esac
+}
+
+available_agents() {
+	local a
+	for a in "${AGENT_ORDER[@]}"; do
+		command -v "$a" >/dev/null 2>&1 && echo "$a"
+	done
+	return 0
+}
+
+first_agent() { available_agents | head -1; }
+
+# Run a one-shot, non-interactive prompt against the first available agent.
+# $1 = tutor context, $2 = user prompt. Prints the agent's answer to stdout.
+# Only claude has a true system-prompt flag in print mode; the others get the
+# context prepended to the prompt, which works well enough for one-shots.
+agent_oneshot() {
+	local context="$1" prompt="$2" agent
+	agent=$(first_agent)
+	if [ -z "$agent" ]; then
+		echo "sqrbx-learn: no AI CLI found (claude, opencode, gemini, or codex)." >&2
+		echo "  Add one with: sqrbx-setup ai" >&2
+		return 1
+	fi
+	echo "Asking $(agent_label "$agent")…" >&2
+	case "$agent" in
+		claude)   claude -p --append-system-prompt "$context" "$prompt" ;;
+		opencode) opencode run "$context"$'\n\n'"$prompt"               ;;
+		gemini)   gemini -p "$context"$'\n\n'"$prompt"                  ;;
+		codex)    codex exec "$context"$'\n\n'"$prompt"                 ;;
+	esac
+}
+
+# Render one-shot markdown answers. Not lesson_pager: answers are short, so
+# inline rendering beats dropping into a pager the user has to quit.
+render_md() {
+	if command -v glow >/dev/null 2>&1; then glow -; else cat; fi
 }
 
 # ── Lesson catalog ───────────────────────────────────────────────────────────
@@ -1239,9 +1303,11 @@ EOF
 # ── Hands-on AI agent (coach mode) ────────────────────────────────────────────
 # Launches the AI coding agent with a "teach me while we work" instruction
 # appended for this session only. The teaching itself is a portable prompt
-# (tutor_prompt) — only the injection is harness-specific. Claude Code's
-# --append-system-prompt lets us inject the coaching persona without touching
-# the workspace's own CLAUDE.md, so it stays session-scoped and opt-in.
+# (tutor_prompt) — only the injection is harness-specific: Claude Code takes
+# it via --append-system-prompt, while OpenCode/Gemini/Codex receive it as a
+# session-opening message (tutor_first_message). Either way it never touches
+# the workspace's own CLAUDE.md/AGENTS.md, so it stays session-scoped and
+# opt-in.
 
 tutor_prompt() {
 	local sl; sl=$(skill_level)
@@ -1291,20 +1357,200 @@ pair programming where they hold the keyboard.
 EOF
 }
 
+# Agents without a session-scoped system-prompt flag get the tutor prompt as
+# the opening message instead, with a preamble asking them to adopt it for the
+# whole session. Weaker than a real system prompt, but portable.
+tutor_first_message() {
+	printf 'Adopt the following as your standing instructions for this ENTIRE session, then greet the operator and ask what task they want to work on.\n\n'
+	tutor_prompt
+}
+
 launch_agent_tutor() {
-	if ! command -v claude >/dev/null 2>&1; then
+	local -a agents=()
+	local a
+	while IFS= read -r a; do [ -n "$a" ] && agents+=("$a"); done < <(available_agents)
+
+	if [ ${#agents[@]} -eq 0 ]; then
 		echo
-		gum style --foreground 214 "Hands-on agent mode currently supports Claude Code, which isn't installed."
-		dim "Add it with: sqrbx-setup ai"
+		gum style --foreground 214 "Hands-on coach mode needs an AI CLI (Claude Code, OpenCode, Gemini CLI, or Codex CLI)."
+		dim "Add one with: sqrbx-setup ai"
 		sleep 2
 		return 0
 	fi
+
+	local agent="${agents[0]}"
+	if [ ${#agents[@]} -gt 1 ]; then
+		local -a labels=()
+		for a in "${agents[@]}"; do labels+=("$(agent_label "$a")"); done
+		local pick
+		pick=$(gum choose --header "Which agent should coach this session?" "${labels[@]}") || return 0
+		for a in "${agents[@]}"; do
+			if [ "$(agent_label "$a")" = "$pick" ]; then agent="$a"; break; fi
+		done
+	fi
+
 	echo
-	green "Launching Claude in hands-on coach mode (skill: $(skill_level))…"
+	green "Launching $(agent_label "$agent") in hands-on coach mode (skill: $(skill_level))…"
 	dim "It hands you commands to run yourself. Say \"just do it\" to let it take over."
-	dim "Exit Claude to return to this menu."
+	dim "Exit the agent to return to this menu."
 	echo
-	claude --append-system-prompt "$(tutor_prompt)" || true
+	case "$agent" in
+		claude)   claude --append-system-prompt "$(tutor_prompt)" || true ;;
+		opencode) opencode --prompt "$(tutor_first_message)"      || true ;;
+		gemini)   gemini -i "$(tutor_first_message)"              || true ;;
+		codex)    codex "$(tutor_first_message)"                  || true ;;
+	esac
+}
+
+# ── One-shot LLM commands: ask / explain ─────────────────────────────────────
+# Deliberately gum-free (like --help/--progress) so they work in pipes,
+# scripts, and degraded environments. Each call costs API tokens on the
+# operator's own agent auth, so both are strictly on-demand.
+
+oneshot_context() {
+	local sl; sl=$(skill_level)
+	cat <<EOF
+You are the squarebox terminal tutor. The operator's self-described terminal
+skill level is: ${sl} — calibrate your answer to that level. Answer in
+concise markdown (it renders in a terminal); no preamble. Prefer the modern
+squarebox toolkit and give the exact command to run: rg (not grep), fd (not
+find), bat (cat is aliased to it), eza (ls is aliased to it), zoxide (cd is
+aliased to it), fzf, delta, difft, yq, xh (not curl), just, glow, gum, gh,
+lazygit, yazi. When a tool deserves a deeper dive, point the operator at its
+lesson: sqrbx-learn <tool>.
+EOF
+}
+
+cmd_ask() {
+	if [ $# -eq 0 ]; then
+		echo "Usage: sqrbx-learn ask \"<question>\"" >&2
+		echo "Example: sqrbx-learn ask \"how do I find files changed in the last day?\"" >&2
+		return 1
+	fi
+	agent_oneshot "$(oneshot_context)" "$*" | render_md
+}
+
+cmd_explain() {
+	local cmdline="$*"
+	if [ -z "$cmdline" ]; then
+		# Best effort: the most recent command from the shell's history file.
+		# A parent shell's in-memory history isn't visible to this process,
+		# so this only sees what has been flushed to disk.
+		local histfile="${HISTFILE:-$HOME/.bash_history}"
+		if [ -f "$histfile" ]; then
+			cmdline=$(tail -n 1 "$histfile" 2>/dev/null || true)
+		fi
+	fi
+	if [ -z "$cmdline" ]; then
+		echo "Usage: sqrbx-learn explain '<command>'" >&2
+		echo "(no command given and no shell history found to fall back on)" >&2
+		return 1
+	fi
+	echo "Explaining: $cmdline" >&2
+	agent_oneshot "$(oneshot_context)" "Explain this shell command flag-by-flag, then summarize what it does overall in one sentence. If it uses a legacy tool that has a better squarebox alternative, show the modern equivalent command and name its lesson. Remember the squarebox aliases: cat=bat --paging=never, ls=eza --icons, cd=zoxide.
+
+Command: ${cmdline}" | render_md
+}
+
+# ── Recap: learn from your agent ─────────────────────────────────────────────
+# `recap --enable` registers a PostToolUse hook (sqrbx-agent-tool-log) in
+# ~/.claude/settings.json that records every squarebox toolkit command the
+# agent runs while it works. `recap` then turns that log into a debrief —
+# you learn the tools from real usage on your real tasks, not from synthetic
+# examples. Hook support is Claude Code-only for now; the recap itself reads
+# a plain log file, so other harnesses can feed it later.
+
+recap_hook_enabled() {
+	[ -f "$CLAUDE_SETTINGS" ] || return 1
+	command -v jq >/dev/null 2>&1 || return 1
+	jq -e --arg cmd "$AGENT_LOG_HOOK" \
+		'.hooks.PostToolUse[]?.hooks[]? | select(.command == $cmd)' \
+		"$CLAUDE_SETTINGS" >/dev/null 2>&1
+}
+
+recap_enable() {
+	if ! command -v jq >/dev/null 2>&1; then
+		echo "sqrbx-learn: jq is required to edit ~/.claude/settings.json." >&2
+		return 1
+	fi
+	if recap_hook_enabled; then
+		echo "Agent tool logging is already enabled."
+		return 0
+	fi
+	mkdir -p "$(dirname "$CLAUDE_SETTINGS")"
+	[ -s "$CLAUDE_SETTINGS" ] || echo '{}' > "$CLAUDE_SETTINGS"
+	local tmp; tmp=$(mktemp)
+	jq --arg cmd "$AGENT_LOG_HOOK" \
+		'.hooks.PostToolUse = ((.hooks.PostToolUse // []) + [{matcher: "Bash", hooks: [{type: "command", command: $cmd}]}])' \
+		"$CLAUDE_SETTINGS" > "$tmp" && mv "$tmp" "$CLAUDE_SETTINGS"
+	echo "✓ Agent tool logging enabled (Claude Code PostToolUse hook)."
+	echo "  New Claude Code sessions will log toolkit commands to:"
+	echo "  $AGENT_LOG"
+	echo "  Review them anytime with: sqrbx-learn recap"
+}
+
+recap_disable() {
+	if ! command -v jq >/dev/null 2>&1; then
+		echo "sqrbx-learn: jq is required to edit ~/.claude/settings.json." >&2
+		return 1
+	fi
+	if ! recap_hook_enabled; then
+		echo "Agent tool logging is not enabled."
+		return 0
+	fi
+	local tmp; tmp=$(mktemp)
+	jq --arg cmd "$AGENT_LOG_HOOK" '
+		.hooks.PostToolUse = [
+			(.hooks.PostToolUse // [])[]
+			| .hooks = ((.hooks // []) | map(select(.command != $cmd)))
+			| select((.hooks | length) > 0)
+		]
+		| if (.hooks.PostToolUse | length) == 0 then del(.hooks.PostToolUse) else . end
+		| if (.hooks | length) == 0 then del(.hooks) else . end
+	' "$CLAUDE_SETTINGS" > "$tmp" && mv "$tmp" "$CLAUDE_SETTINGS"
+	echo "✓ Agent tool logging disabled."
+}
+
+cmd_recap() {
+	case "${1:-}" in
+		--enable)  recap_enable;  return 0 ;;
+		--disable) recap_disable; return 0 ;;
+	esac
+
+	if ! [ -s "$AGENT_LOG" ]; then
+		echo "No agent activity logged yet."
+		if recap_hook_enabled; then
+			echo "Logging is enabled — run some Claude Code sessions, then come back."
+		else
+			echo "Enable logging first:  sqrbx-learn recap --enable"
+			echo "It records the squarebox toolkit commands your Claude Code agent"
+			echo "runs while working, so you can learn the tools from its real usage."
+		fi
+		return 0
+	fi
+
+	echo "Toolkit commands your agent has run ($(wc -l < "$AGENT_LOG") logged):"
+	echo
+	local count tool example
+	cut -d'|' -f2 "$AGENT_LOG" | sort | uniq -c | sort -rn | while read -r count tool; do
+		example=$(awk -F'|' -v t="$tool" '$2 == t { sub(/^[^|]*\|[^|]*\|/, ""); last = $0 } END { print last }' "$AGENT_LOG")
+		printf '  %4d× %-8s %s\n' "$count" "$tool" "${example:0:60}"
+	done
+	echo
+	echo "Deep dive on any of these:  sqrbx-learn <tool>"
+
+	# Optional AI debrief — interactive terminals only, and only when an
+	# agent and gum are around, since it costs tokens and needs a confirm.
+	local agent; agent=$(first_agent)
+	if [ -n "$agent" ] && [ -t 0 ] && [ -t 1 ] && command -v gum >/dev/null 2>&1; then
+		echo
+		if gum confirm "Get an AI debrief of what these commands did?" --default=true; then
+			local recent; recent=$(tail -n 40 "$AGENT_LOG" | cut -d'|' -f2-)
+			agent_oneshot "$(oneshot_context)" "Here are squarebox toolkit commands my AI agent recently ran while working in my repo, one per line as tool|command. Pick the 3-5 most instructive, explain what each did and what its flags mean, and end with one takeaway trick I can use myself.
+
+${recent}" | render_md
+		fi
+	fi
 }
 
 # ── Lesson deep-linking ───────────────────────────────────────────────────────
@@ -1450,15 +1696,24 @@ usage() {
 	sqrbx-learn — interactive terminal learning guide
 
 	Usage:
-	  sqrbx-learn            Open the menu (hands-on AI agent mode, or browse lessons)
-	  sqrbx-learn <tool>     Jump straight to a tool's lesson (e.g. sqrbx-learn rg)
-	  sqrbx-learn --progress Show your progress
-	  sqrbx-learn --reset    Reset all progress AND skill level (re-prompts on next launch)
-	  sqrbx-learn --help     Show this help
+	  sqrbx-learn                  Open the menu (hands-on AI agent mode, or browse lessons)
+	  sqrbx-learn <tool>           Jump straight to a tool's lesson (e.g. sqrbx-learn rg)
+	  sqrbx-learn ask "<question>" Ask your configured AI CLI a toolkit question (one-shot)
+	  sqrbx-learn explain ['<cmd>'] Explain a command flag-by-flag (defaults to your last one)
+	  sqrbx-learn recap            Review the toolkit commands your AI agent has been running
+	  sqrbx-learn recap --enable   Start logging agent commands (Claude Code hook)
+	  sqrbx-learn recap --disable  Stop logging agent commands
+	  sqrbx-learn --progress       Show your progress
+	  sqrbx-learn --reset          Reset all progress AND skill level (re-prompts on next launch)
+	  sqrbx-learn --help           Show this help
 
-	Hands-on agent mode (the top menu entry) launches Claude Code as a coach for
-	the session: instead of doing the work for you, it hands you each command to
+	Hands-on agent mode (the top menu entry) launches your configured AI CLI
+	(Claude Code, OpenCode, Gemini CLI, or Codex CLI) as a coach for the
+	session: instead of doing the work for you, it hands you each command to
 	run yourself and explains why. Say "just do it" to let it take over.
+
+	ask/explain/recap use the same AI CLI non-interactively — each call runs
+	on your own agent auth and costs tokens, so they only fire on demand.
 
 	Inside the guide:
 	  ↑↓ / jk    Navigate lessons
@@ -1489,6 +1744,18 @@ case "${1:-}" in
 			&& green "✓ Progress reset." \
 			|| dim "Cancelled."
 		exit 0
+		;;
+	ask)
+		shift
+		cmd_ask "$@"
+		;;
+	explain)
+		shift
+		cmd_explain "$@"
+		;;
+	recap)
+		shift
+		cmd_recap "$@"
 		;;
 	"")
 		main

--- a/scripts/squarebox-help.sh
+++ b/scripts/squarebox-help.sh
@@ -30,7 +30,7 @@ EOF
 
 cmd_row sqrbx-setup  "Re-run the setup wizard to add/change tools (--list, --help)"
 cmd_row sqrbx-update "Update installed tool binaries in-place from upstream"
-cmd_row sqrbx-learn  "Learn the toolkit hands-on with your AI agent"
+cmd_row sqrbx-learn  "Learn the toolkit hands-on with your AI agent (ask, explain, recap)"
 cmd_row sqrbx-help   "Show this overview"
 
 cat <<-EOF


### PR DESCRIPTION
Learn mode's hands-on coach was Claude Code-only and one-directional.
This makes the LLM integration work with whichever AI CLI is configured
and adds two new interactive directions:

- Coach mode now launches any configured agent (Claude Code, OpenCode,
  Gemini CLI, Codex CLI), picking via gum when several are installed.
  Claude keeps --append-system-prompt; the others get the tutor prompt
  as a session-opening instruction, so nothing touches the workspace's
  CLAUDE.md/AGENTS.md.
- sqrbx-learn ask/explain: gum-free one-shots against the same agent.
  ask answers toolkit questions with the exact command to run; explain
  breaks a command down flag-by-flag (defaulting to the last one in
  shell history) and suggests the modern squarebox equivalent.
- sqrbx-learn recap: learn from your agent's real work. recap --enable
  registers a Claude Code PostToolUse hook (sqrbx-agent-tool-log) that
  logs toolkit commands the agent runs; recap shows per-tool counts
  with real examples, deep-links lessons, and optionally hands the
  recent log to the agent for a debrief. --disable removes the hook
  and preserves unrelated settings.json keys.

The hook never blocks the agent (always exits 0, trims its own log)
and e2e covers install, logging, recap summary, and the enable/disable
round-trip.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C8rh2iRMDARmBGxcSrevxU