### PR TITLE
feat: install openssh-client so ssh is available in the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,10 @@ RUN printf 'path-include=/usr/share/doc/fzf/examples/key-bindings.bash\n' \
 		> /etc/dpkg/dpkg.cfg.d/zz-squarebox-fzf \
 	&& apt-get update && apt-get install -y --no-install-recommends \
 	git \
+	# openssh-client: git only Recommends it, so --no-install-recommends drops it.
+	# Needed for SSH git remotes and the agent-forwarding mounts (SSH_AUTH_SOCK,
+	# ~/.ssh/config, ~/.ssh/known_hosts) set up at run time.
+	openssh-client \
 	curl \
 	unzip \
 	jq \

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -84,6 +84,10 @@ suite_tools() {
 
 	# 5.14 difftastic version (binary is named `difft`)
 	run_test "5.14 difft --version" difft --version
+
+	# 5.15 ssh client present (openssh-client — git only Recommends it, so
+	# --no-install-recommends would drop it without an explicit install)
+	run_test "5.15 ssh installed" command -v ssh
 }
 
 # ── Suite: shell ─────────────────────────────────────────────────────────


### PR DESCRIPTION
git only Recommends ssh-client, and the base apt layer uses
--no-install-recommends, so the ssh client binary was never installed.
The image already wires up SSH agent forwarding at run time
(SSH_AUTH_SOCK, ~/.ssh/config, ~/.ssh/known_hosts mounts) and creates
~/.ssh, but SSH git remotes and `ssh` itself would fail with
command-not-found. Add openssh-client explicitly and cover it with an
e2e check.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MfGrhHGzMHHpsnS24aJy3K