### PR TITLE
fix: align learn-mode prompts with zoxide z/zi and dedupe e2e test labels

### DIFF
--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -91,7 +91,7 @@ suite_tools() {
 }
 
 # ── Suite: shell ─────────────────────────────────────────────────────────
-# Covers: 4.1-4.7 (shell environment)
+# Covers: 4.1-4.8 (shell environment)
 
 suite_shell() {
 	# 4.1 starship prompt in bashrc
@@ -103,9 +103,9 @@ suite_shell() {
 	# 4.3 MOTD runs without error
 	run_test "4.3 motd.sh runs" /usr/local/lib/squarebox/motd.sh
 
-	# 4.4 squarebox version is baked in and surfaced by the MOTD
-	run_test "4.4 VERSION file present and non-empty" test -s /usr/local/lib/squarebox/VERSION
-	run_test_grep "4.5 motd shows the baked version" \
+	# 4.8 squarebox version is baked in and surfaced by the MOTD
+	run_test "4.8a VERSION file present and non-empty" test -s /usr/local/lib/squarebox/VERSION
+	run_test_grep "4.8b motd shows the baked version" \
 		"$(cat /usr/local/lib/squarebox/VERSION)" \
 		bash /usr/local/lib/squarebox/motd.sh
 

--- a/scripts/sqrbx-learn
+++ b/scripts/sqrbx-learn
@@ -1415,9 +1415,9 @@ You are the squarebox terminal tutor. The operator's self-described terminal
 skill level is: ${sl} — calibrate your answer to that level. Answer in
 concise markdown (it renders in a terminal); no preamble. Prefer the modern
 squarebox toolkit and give the exact command to run: rg (not grep), fd (not
-find), bat (cat is aliased to it), eza (ls is aliased to it), zoxide (cd is
-aliased to it), fzf, delta, difft, yq, xh (not curl), just, glow, gum, gh,
-lazygit, yazi. When a tool deserves a deeper dive, point the operator at its
+find), bat (cat is aliased to it), eza (ls is aliased to it), zoxide (jump
+with z, pick with zi), fzf, delta, difft, yq, xh (not curl), just, glow, gum,
+gh, lazygit, yazi. When a tool deserves a deeper dive, point the operator at its
 lesson: sqrbx-learn <tool>.
 EOF
 }
@@ -1448,7 +1448,7 @@ cmd_explain() {
 		return 1
 	fi
 	echo "Explaining: $cmdline" >&2
-	agent_oneshot "$(oneshot_context)" "Explain this shell command flag-by-flag, then summarize what it does overall in one sentence. If it uses a legacy tool that has a better squarebox alternative, show the modern equivalent command and name its lesson. Remember the squarebox aliases: cat=bat --paging=never, ls=eza --icons, cd=zoxide.
+	agent_oneshot "$(oneshot_context)" "Explain this shell command flag-by-flag, then summarize what it does overall in one sentence. If it uses a legacy tool that has a better squarebox alternative, show the modern equivalent command and name its lesson. Remember the squarebox aliases: cat=bat --paging=never, ls=eza --icons, and zoxide provides z/zi for directory jumps.
 
 Command: ${cmdline}" | render_md
 }


### PR DESCRIPTION
Post-merge cleanup after #92–#95 landed together, ahead of the v1.1.0 tag:

- **sqrbx-learn prompts taught a stale alias.** `oneshot_context` and the `explain` prompt (from #94) still told the LLM that `cd` is aliased to zoxide; since #92 the box ships zoxide's default `z`/`zi` with the `cd` builtin untouched. Both prompts now say `z`/`zi`.
- **Duplicate e2e test labels.** The MOTD-version checks from #93 reused the `4.4`/`4.5` labels already taken in `suite_shell`; renumbered to `4.8a`/`4.8b` and extended the suite's covers comment to 4.1–4.8.

No behavior changes beyond prompt wording and test labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167rcXNKL24gkg5Vz6CsNoR

---
_Generated by [Claude Code](https://claude.ai/code/session_0167rcXNKL24gkg5Vz6CsNoR)_