### PR TITLE
add paseo to AI coding assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ scripted installs). Values use the same keys as `sqrbx-setup`:
 
 | Variable | Selects |
 |----------|---------|
-| `SQUAREBOX_AI` | AI assistants (`claude,copilot,gemini,codex,opencode,pi`) |
+| `SQUAREBOX_AI` | AI assistants (`claude,copilot,gemini,codex,opencode,pi,paseo`) |
 | `SQUAREBOX_SDKS` | language SDKs (`node,python,go,dotnet,rust`) |
 | `SQUAREBOX_EDITORS` | editors (`micro,edit,fresh,nvim`) |
 | `SQUAREBOX_TUIS` | TUI tools (`lazygit,gh-dash,yazi`) |
@@ -227,6 +227,7 @@ pre-selected non-interactively via the `SQUAREBOX_AI`/`SQUAREBOX_SDKS`/… env v
 | [OpenAI Codex CLI](https://github.com/openai/codex) | TypeScript | OpenAI Codex in the terminal * |
 | [opencode](https://github.com/anomalyco/opencode) | Go | AI coding TUI |
 | [Pi Coding Agent](https://github.com/earendil-works/pi) | TypeScript | Minimal terminal coding harness (Earendil) * |
+| [Paseo](https://paseo.sh) | TypeScript | Remote control for AI CLI agents * |
 
 \* Requires Node.js (auto-installed if needed).
 

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -182,7 +182,7 @@ suite_setup() {
 suite_setup_editors() {
 	# Pre-seed selections in /workspace/.squarebox/
 	mkdir -p /workspace/.squarebox
-	echo "opencode,pi" > /workspace/.squarebox/ai-tool
+	echo "opencode,pi,paseo" > /workspace/.squarebox/ai-tool
 	echo "micro,edit,fresh,nvim" > /workspace/.squarebox/editors
 	echo "lazygit,gh-dash,yazi" > /workspace/.squarebox/tuis
 	echo "tmux,zellij" > /workspace/.squarebox/multiplexer
@@ -214,6 +214,7 @@ suite_setup_editors() {
 	# 3.7 editors installed
 	run_test "3.7a opencode installed" command -v opencode
 	run_test "3.7a2 pi installed" command -v pi
+	run_test "3.7a3 paseo installed" command -v paseo
 	run_test "3.7b micro installed" command -v micro
 	run_test "3.7c edit installed" command -v edit
 	run_test "3.7d fresh installed" command -v fresh

--- a/scripts/squarebox-setup.sh
+++ b/scripts/squarebox-setup.sh
@@ -31,7 +31,7 @@ usage() {
 	${BOLD}Sections:${RESET}
 	  git            Git identity (name, email)
 	  github         GitHub CLI authentication
-	  ai             AI coding assistants (claude, copilot, gemini, codex, opencode, pi)
+	  ai             AI coding assistants (claude, copilot, gemini, codex, opencode, pi, paseo)
 	  editors        Text editors (micro, edit, fresh, nvim)
 	  tuis           TUI tools (lazygit, gh-dash, yazi)
 	  multiplexers   Terminal multiplexers (tmux, zellij)

--- a/setup.sh
+++ b/setup.sh
@@ -361,13 +361,14 @@ if $INTERACTIVE; then
 				codex)    gum_selected="${gum_selected:+$gum_selected,}OpenAI Codex CLI" ;;
 				opencode) gum_selected="${gum_selected:+$gum_selected,}OpenCode" ;;
 				pi)       gum_selected="${gum_selected:+$gum_selected,}Pi Coding Agent" ;;
+				paseo)    gum_selected="${gum_selected:+$gum_selected,}Paseo" ;;
 			esac
 		done
 		gum_args=(--no-limit --header "Select AI coding assistants (space=toggle, enter=confirm):")
 		[ -n "$gum_selected" ] && gum_args+=(--selected "$gum_selected")
 		selected=$(gum choose "${gum_args[@]}" \
 			"Claude Code" "GitHub Copilot CLI" "Google Gemini CLI" \
-			"OpenAI Codex CLI" "OpenCode" "Pi Coding Agent") || true
+			"OpenAI Codex CLI" "OpenCode" "Pi Coding Agent" "Paseo") || true
 		ai_choice=""
 		while IFS= read -r line; do
 			case "$line" in
@@ -377,11 +378,12 @@ if $INTERACTIVE; then
 				"OpenAI Codex CLI")   ai_choice="${ai_choice:+$ai_choice,}codex" ;;
 				"OpenCode")           ai_choice="${ai_choice:+$ai_choice,}opencode" ;;
 				"Pi Coding Agent")    ai_choice="${ai_choice:+$ai_choice,}pi" ;;
+				"Paseo")              ai_choice="${ai_choice:+$ai_choice,}paseo" ;;
 			esac
 		done <<< "$selected"
 	else
 		echo "Select AI coding assistants (comma-separated, 'all', or press Enter to skip):"
-		for ai_item in "1:claude:Claude Code" "2:copilot:GitHub Copilot CLI" "3:gemini:Google Gemini CLI" "4:codex:OpenAI Codex CLI" "5:opencode:OpenCode" "6:pi:Pi Coding Agent"; do
+		for ai_item in "1:claude:Claude Code" "2:copilot:GitHub Copilot CLI" "3:gemini:Google Gemini CLI" "4:codex:OpenAI Codex CLI" "5:opencode:OpenCode" "6:pi:Pi Coding Agent" "7:paseo:Paseo"; do
 			num="${ai_item%%:*}"; rest="${ai_item#*:}"; key="${rest%%:*}"; label="${rest#*:}"
 			if [[ ",$ai_prev," == *",${key},"* ]]; then
 				echo "  ${num}) ${label} [installed]"
@@ -389,13 +391,13 @@ if $INTERACTIVE; then
 				echo "  ${num}) ${label}"
 			fi
 		done
-		read -rp "Selection [1,2,3,4,5,6/all/skip]: " ai_selection
+		read -rp "Selection [1-7/all/skip]: " ai_selection
 		if [ -z "$ai_selection" ] && [ -n "$ai_prev" ]; then
 			ai_choice="$ai_prev"
 		else
 			ai_choice=""
 			if [ "$ai_selection" = "all" ]; then
-				ai_choice="claude,copilot,gemini,codex,opencode,pi"
+				ai_choice="claude,copilot,gemini,codex,opencode,pi,paseo"
 			elif [ -n "$ai_selection" ]; then
 				for item in $(echo "$ai_selection" | tr ',' ' '); do
 					case "$item" in
@@ -405,6 +407,7 @@ if $INTERACTIVE; then
 						4) ai_choice="${ai_choice:+$ai_choice,}codex" ;;
 						5) ai_choice="${ai_choice:+$ai_choice,}opencode" ;;
 						6) ai_choice="${ai_choice:+$ai_choice,}pi" ;;
+					7) ai_choice="${ai_choice:+$ai_choice,}paseo" ;;
 					esac
 				done
 			fi
@@ -445,6 +448,12 @@ install_pi() {
 	run_with_spinner "Installing Pi Coding Agent..." npm install -g --silent --ignore-scripts @earendil-works/pi-coding-agent
 }
 
+install_paseo() {
+	if command -v paseo &>/dev/null; then echo "Paseo already installed, skipping."; return 0; fi
+	ensure_node_for_npm
+	run_with_spinner "Installing Paseo..." npm install -g --silent @getpaseo/cli
+}
+
 for ai_tool in $(echo "$ai_choice" | tr ',' ' '); do
 	case "$ai_tool" in
 		claude)
@@ -466,13 +475,14 @@ for ai_tool in $(echo "$ai_choice" | tr ',' ' '); do
 		gemini)   install_gemini || echo "Warning: Google Gemini CLI installation failed." ;;
 		codex)    install_codex || echo "Warning: OpenAI Codex CLI installation failed." ;;
 		pi)       install_pi || echo "Warning: Pi Coding Agent installation failed." ;;
+		paseo)    install_paseo || echo "Warning: Paseo installation failed." ;;
 	esac
 done
 
 # Set aliases based on selection — c maps to first selected tool in priority order
 {
 	c_target=""
-	for ai_tool in claude copilot gemini codex opencode pi; do
+	for ai_tool in claude copilot gemini codex opencode pi paseo; do
 		if [[ ",$ai_choice," == *",$ai_tool,"* ]]; then
 			[ -z "$c_target" ] && c_target="$ai_tool"
 			case "$ai_tool" in


### PR DESCRIPTION
## Changes

- Add **paseo** as an optional AI coding assistant in setup.sh
- Installed via `npm install -g @getpaseo/cli` (same npm pattern as copilot/gemini/codex/pi)
- Menu option **7**, key `paseo`, display name `Paseo`

## Files modified

| File | Changes |
|------|---------|
| `setup.sh` | Gum pre-select, gum choice list, gum result mapping, non-gum menu, prompt text, \all\ expansion, numeric selection, `install_paseo()` function, install dispatch, alias priority |
| `scripts/squarebox-setup.sh` | Help text |
| `README.md` | `SQUAREBOX_AI` env var table + AI tools table |
| `scripts/e2e-test.sh` | Pre-seeded config + validation test |

## Behavior

- Alias priority: last (only wins `c` if nothing else is selected)
- No `-yolo` alias (it's a remote-control tool, not a direct coding agent)
- Not in `tools.yaml` / `sqrbx-update` (npm-installed, like copilot/gemini/codex/pi)