### PR TITLE
Wait for Box reconciliation in lifecycle E2E

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -312,6 +312,17 @@ jobs:
             --cap-drop=ALL --cap-add=CHOWN --cap-add=DAC_OVERRIDE
             --cap-add=FOWNER --cap-add=SETUID --cap-add=SETGID --cap-add=KILL
           )
+          wait_for_box_ready() {
+            local _
+            for _ in {1..60}; do
+              if docker exec "$box" sh -c 'test "$(cat /proc/1/comm)" = sleep'; then
+                return 0
+              fi
+              sleep 1
+            done
+            docker logs "$box" >&2
+            return 1
+          }
           docker volume create "$home_volume" >/dev/null
           docker volume create "$workspace_volume" >/dev/null
           docker run -d --name "$box" \
@@ -320,6 +331,7 @@ jobs:
             -v "$workspace_volume:/workspace" \
             -v /etc/localtime:/etc/localtime:ro \
             squarebox:test sleep infinity
+          wait_for_box_ready
           docker exec -u dev "$box" bash -c '
             mkdir -p /workspace/.squarebox
             printf "tmux\n" > /workspace/.squarebox/multiplexer
@@ -329,6 +341,7 @@ jobs:
           '
           docker stop "$box" >/dev/null
           docker start "$box" >/dev/null
+          wait_for_box_ready
           docker exec -u dev "$box" bash -c \
             'grep -qx restart-ok ~/.squarebox-e2e-state && command -v tmux >/dev/null'
           scripts/e2e-evidence.sh pass lifecycle.restart \
@@ -341,6 +354,7 @@ jobs:
             -v "$workspace_volume:/workspace" \
             -v /etc/localtime:/etc/localtime:ro \
             squarebox:test sleep infinity
+          wait_for_box_ready
           docker exec -u dev "$box" bash -c \
             'grep -qx restart-ok ~/.squarebox-e2e-state && command -v tmux >/dev/null'
           scripts/e2e-evidence.sh pass lifecycle.recreate \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,8 @@
 - CI reports claiming behavior that was not executed.
 - Release-candidate failures caused by a Compose UID-remap startup race,
   cross-UID Evidence file permissions, LazyGit's lowercase Linux asset name,
-  and Gum release binaries built with a vulnerable Go standard library.
+  Gum release binaries built with a vulnerable Go standard library, and raw
+  lifecycle assertions racing synchronous Box-tier reconciliation.
 
 ### Removed
 

--- a/tests/test-e2e-evidence.sh
+++ b/tests/test-e2e-evidence.sh
@@ -113,6 +113,10 @@ grep -Fq 'docker compose up -d --force-recreate --no-deps squarebox' "$WORKFLOW"
 grep -Fq 'test "$replacement_box" != "$original_box"' "$WORKFLOW"
 test "$(grep -Fc 'wait_for_compose_workspace' "$WORKFLOW")" -eq 3
 grep -Fq 'test "$(stat -c %u /proc/1)" = "$1" && test -w /workspace' "$WORKFLOW"
+# Raw Docker lifecycle assertions must wait for the entrypoint's synchronous
+# Box-tier reconciliation after create, restart, and replacement.
+test "$(grep -Fc 'wait_for_box_ready' "$WORKFLOW")" -eq 4
+grep -Fq 'test "$(cat /proc/1/comm)" = sleep' "$WORKFLOW"
 grep -Fq '~/.squarebox-compose-e2e' "$WORKFLOW"
 grep -Fq '$SQUAREBOX_WORKSPACE/from-compose' "$WORKFLOW"
 grep -Fq -- '--cap-drop=ALL --cap-add=CHOWN --cap-add=DAC_OVERRIDE' "$WORKFLOW"


### PR DESCRIPTION
## Summary

- wait for the raw Docker entrypoint to finish synchronous Box-tier reconciliation after create, restart, and replacement
- keep persisted-state and tmux assertions as independent correctness gates
- add a repository guard requiring all three readiness boundaries
- record the RC6 test-race correction in the v1.1.0 changelog

## RC6 root cause

The replacement assertion ran immediately after docker run returned. PID 1 was still the entrypoint reinstalling the saved tmux Selection, so the assertion raced reconciliation and failed before lifecycle.recreate Evidence could be written.

## Validation

- three consecutive real create, stop/start, and replacement cycles passed
- all 17 executable test modules passed
- Actionlint 1.7.12 passed
- ShellCheck 0.9.0 passed
- workflow YAML and repository consistency passed
- independent agent review found no blocking issue