### PR TITLE
Isolate multi-platform release verification

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -668,6 +668,9 @@ jobs:
             docker pull --platform "$platform" "$IMAGE@$DIGEST"
             docker run --rm --platform "$platform" "$IMAGE@$DIGEST" \
               grep -qx "$GITHUB_REF_NAME" /usr/local/lib/squarebox/VERSION
+            # Docker's classic image store cannot associate two platform
+            # members with the same manifest-list digest at once.
+            docker image rm "$IMAGE@$DIGEST" >/dev/null
           done
 
       - name: Create, sign, and verify digest-bound release assets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,8 @@
 - Release-candidate failures caused by a Compose UID-remap startup race,
   cross-UID Evidence file permissions, LazyGit's lowercase Linux asset name,
   Gum release binaries built with a vulnerable Go standard library, and raw
-  lifecycle assertions racing synchronous Box-tier reconciliation.
+  lifecycle assertions racing synchronous Box-tier reconciliation; release
+  preparation now isolates multi-platform pulls in Docker's local image store.
 
 ### Removed
 

--- a/tests/test-e2e-evidence.sh
+++ b/tests/test-e2e-evidence.sh
@@ -160,6 +160,26 @@ for release_doc in \
 	grep -Fq 'immutable' "$release_doc"
 done
 
+# Docker's classic image store must release the shared manifest-list digest
+# only after each explicit-platform image has verified its embedded version.
+ruby - "$WORKFLOW" <<'RUBY'
+require "yaml"
+
+workflow = YAML.safe_load_file(ARGV.fetch(0), aliases: true)
+step = workflow.fetch("jobs").fetch("prepare-release").fetch("steps").find do |candidate|
+  candidate["name"] == "Verify exact Candidate identity and architecture content"
+end
+abort "Candidate identity verification step is missing" unless step
+script = step.fetch("run")
+loop_body = script[/for platform in linux\/amd64 linux\/arm64; do\n(?<body>.*?)\n\s*done/m, :body]
+abort "Candidate platform verification loop is missing" unless loop_body
+pull = loop_body.index('docker pull --platform "$platform" "$IMAGE@$DIGEST"')
+verify = loop_body.index('grep -qx "$GITHUB_REF_NAME" /usr/local/lib/squarebox/VERSION')
+remove = loop_body.index('docker image rm "$IMAGE@$DIGEST"')
+ordered = pull && verify && remove && pull < verify && verify < remove
+abort "Candidate platform images are not isolated after verification" unless ordered
+RUBY
+
 # Stable Release preparation and publication are deliberately separate jobs.
 # The final job selects the protected production environment only for stable
 # versions; prereleases use an unprotected environment and continue


### PR DESCRIPTION
## Summary

- remove each runner-local platform image after its exact-digest VERSION assertion
- prevent Docker classic image storage from reusing one manifest-list digest association across amd64 and arm64
- preserve remote digest identity, signing, and all later release gates
- add an ordering regression proving pull, verify, then removal remain inside the platform loop

## RC7 root cause

Every runtime, lifecycle, evidence, and security gate passed. Release preparation pulled amd64 under the multi-arch digest, then Docker refused to overwrite that local digest association with arm64 and reported cannot overwrite digest.

## Validation

- RC7 exact published digest passed native amd64 verification
- the same digest passed emulated arm64 verification after local reference removal
- all 17 executable test modules passed
- Actionlint 1.7.12 passed
- ShellCheck 0.9.0 passed
- workflow YAML and diff checks passed
- independent agent review found no blocking issue