### PR TITLE
chore: remove Paseo assistant support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Removed
+
+- Paseo assistant installation and Selection support.
+
 ## v1.1.0 — 2026-07-16
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ GitHub authentication uses the normal Managed-home `~/.config/gh` plus
 `~/.squarebox-gh-skip`; legacy Workspace markers are migrated.
 
 Supported assistant keys include `claude`, `copilot`, `gemini`, `codex`,
-`opencode`, `pi`, and `paseo`. Copilot is `@github/copilot`, binary `copilot`,
+`opencode`, and `pi`. Copilot is `@github/copilot`, binary `copilot`,
 and needs Node 22 or newer. SDKs are managed by mise. Editors include micro,
 edit, fresh, Helix (`hx`), and Neovim/LazyVim.
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ scripted installs). Values use the same keys as `sqrbx-setup`:
 
 | Variable | Selects |
 |----------|---------|
-| `SQUAREBOX_AI` | AI assistants (`claude,copilot,gemini,codex,opencode,pi,paseo`) |
+| `SQUAREBOX_AI` | AI assistants (`claude,copilot,gemini,codex,opencode,pi`) |
 | `SQUAREBOX_SDKS` | language SDKs (`node,python,go,dotnet,rust`) |
 | `SQUAREBOX_EDITORS` | editors (`micro,edit,fresh,helix,nvim`; Helix launches as `hx`) |
 | `SQUAREBOX_TUIS` | TUI tools (`lazygit,gh-dash,yazi`) |
@@ -256,8 +256,6 @@ pre-selected non-interactively via the `SQUAREBOX_AI`/`SQUAREBOX_SDKS`/… env v
 | [OpenAI Codex CLI](https://github.com/openai/codex) | Rust | OpenAI Codex in the terminal * |
 | [opencode](https://github.com/anomalyco/opencode) | TypeScript/Bun | AI coding TUI |
 | [Pi Coding Agent](https://github.com/earendil-works/pi) | TypeScript | Minimal terminal coding harness (Earendil) * |
-| [Paseo](https://paseo.sh) | TypeScript | Remote control for AI CLI agents * |
-
 \* Requires Node.js (auto-installed if needed).
 
 ### Text Editors
@@ -472,7 +470,6 @@ First-run selections add to that:
 | OpenAI Codex CLI | ~50 MB |
 | OpenCode | ~30 MB |
 | Pi Coding Agent | ~50 MB |
-| Paseo | Varies by npm release |
 | lazygit / gh-dash / yazi | ~10 / ~10 / ~10 MB |
 | micro / edit | ~12 / ~7 MB |
 | fresh / nvim | ~10 / ~45 MB |
@@ -504,7 +501,7 @@ updating an already observed registered tool to a newer authorized release.
 SDKs (Node, Python, Go, .NET, Rust) are installed by [mise](https://github.com/jdx/mise),
 which is itself a Dockerfile-tier pinned binary. mise downloads each SDK
 toolchain from its upstream over HTTPS using its own integrity checks. npm-based
-AI tools (Copilot CLI, Gemini CLI, Codex CLI, Pi, and Paseo) use npm's built-in
+AI tools (Copilot CLI, Gemini CLI, Codex CLI, and Pi) use npm's built-in
 integrity verification.
 
 For the full trust model (what `install.sh` does on your machine, how each
@@ -528,7 +525,7 @@ container environment variables (set to an empty string to opt out of a tier):
 
 | Variable | Default | Selects |
 |----------|---------|---------|
-| `SQUAREBOX_DC_AI` | `claude` | AI assistants (`claude,copilot,gemini,codex,opencode,pi,paseo`) |
+| `SQUAREBOX_DC_AI` | `claude` | AI assistants (`claude,copilot,gemini,codex,opencode,pi`) |
 | `SQUAREBOX_DC_SDKS` | `node` | SDKs (`node,python,go,dotnet,rust`) |
 | `SQUAREBOX_DC_EDITORS` | _(none)_ | Editors (`micro,edit,fresh,helix,nvim`; Helix launches as `hx`) |
 | `SQUAREBOX_DC_TUIS` | _(none)_ | TUI tools (`lazygit,gh-dash,yazi`) |

--- a/demo/setup-demo.sh
+++ b/demo/setup-demo.sh
@@ -35,7 +35,7 @@ section_header "AI Coding Assistants"
 selected=$(gum choose --no-limit \
     --header "Select AI coding assistants (space=toggle, enter=confirm):" \
     "Claude Code" "GitHub Copilot CLI" "Google Gemini CLI" \
-    "OpenAI Codex CLI" "OpenCode" "Pi Coding Agent" "Paseo") || true
+    "OpenAI Codex CLI" "OpenCode" "Pi Coding Agent") || true
 
 node_installed=false
 while IFS= read -r line; do
@@ -44,7 +44,7 @@ while IFS= read -r line; do
         "Claude Code")
             run_with_spinner "Installing Claude Code..." 0.8
             ;;
-        "GitHub Copilot CLI"|"Google Gemini CLI"|"OpenAI Codex CLI"|"Pi Coding Agent"|"Paseo")
+        "GitHub Copilot CLI"|"Google Gemini CLI"|"OpenAI Codex CLI"|"Pi Coding Agent")
             if ! $node_installed; then
                 run_with_spinner "Installing Node.js (via mise)..." 1
                 node_installed=true

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -224,7 +224,7 @@ suite_setup() {
 suite_setup_editors() {
 	# Pre-seed selections in /workspace/.squarebox/
 	mkdir -p /workspace/.squarebox
-	echo "opencode,pi,paseo" > /workspace/.squarebox/ai-tool
+	echo "opencode,pi" > /workspace/.squarebox/ai-tool
 	echo "micro,edit,fresh,helix,nvim" > /workspace/.squarebox/editors
 	echo "lazygit,gh-dash,yazi" > /workspace/.squarebox/tuis
 	echo "tmux,zellij" > /workspace/.squarebox/multiplexer
@@ -260,7 +260,6 @@ suite_setup_editors() {
 	# 3.7 editors installed
 	run_test "3.7a opencode installed" command -v opencode
 	run_test "3.7a2 pi installed" command -v pi
-	run_test "3.7a3 paseo installed" command -v paseo
 	run_test "3.7b micro installed" command -v micro
 	run_test "3.7c edit installed" command -v edit
 	run_test "3.7d fresh installed" command -v fresh

--- a/scripts/squarebox-setup.sh
+++ b/scripts/squarebox-setup.sh
@@ -31,7 +31,7 @@ usage() {
 	${BOLD}Sections:${RESET}
 	  git            Git identity (name, email)
 	  github         GitHub CLI authentication
-	  ai             AI coding assistants (claude, copilot, gemini, codex, opencode, pi, paseo)
+	  ai             AI coding assistants (claude, copilot, gemini, codex, opencode, pi)
 	  editors        Text editors (micro, edit, fresh, helix/hx, nvim)
 	  tuis           TUI tools (lazygit, gh-dash, yazi)
 	  multiplexers   Terminal multiplexers (tmux, zellij)

--- a/setup.sh
+++ b/setup.sh
@@ -530,14 +530,13 @@ if $INTERACTIVE; then
 				codex)    gum_selected="${gum_selected:+$gum_selected,}OpenAI Codex CLI" ;;
 				opencode) gum_selected="${gum_selected:+$gum_selected,}OpenCode" ;;
 				pi)       gum_selected="${gum_selected:+$gum_selected,}Pi Coding Agent" ;;
-				paseo)    gum_selected="${gum_selected:+$gum_selected,}Paseo" ;;
 			esac
 		done
 		gum_args=(--no-limit --header "Select AI coding assistants (space=toggle, enter=confirm):")
 		[ -n "$gum_selected" ] && gum_args+=(--selected "$gum_selected")
 		if ! selected=$(gum choose "${gum_args[@]}" \
 			"Claude Code" "GitHub Copilot CLI" "Google Gemini CLI" \
-			"OpenAI Codex CLI" "OpenCode" "Pi Coding Agent" "Paseo"); then
+			"OpenAI Codex CLI" "OpenCode" "Pi Coding Agent"); then
 			cancel_setup
 		fi
 		ai_choice=""
@@ -549,12 +548,11 @@ if $INTERACTIVE; then
 				"OpenAI Codex CLI")   ai_choice="${ai_choice:+$ai_choice,}codex" ;;
 				"OpenCode")           ai_choice="${ai_choice:+$ai_choice,}opencode" ;;
 				"Pi Coding Agent")    ai_choice="${ai_choice:+$ai_choice,}pi" ;;
-				"Paseo")              ai_choice="${ai_choice:+$ai_choice,}paseo" ;;
 			esac
 		done <<< "$selected"
 	else
 		echo "Select AI coding assistants (comma-separated, 'all', or press Enter to skip):"
-		for ai_item in "1:claude:Claude Code" "2:copilot:GitHub Copilot CLI" "3:gemini:Google Gemini CLI" "4:codex:OpenAI Codex CLI" "5:opencode:OpenCode" "6:pi:Pi Coding Agent" "7:paseo:Paseo"; do
+		for ai_item in "1:claude:Claude Code" "2:copilot:GitHub Copilot CLI" "3:gemini:Google Gemini CLI" "4:codex:OpenAI Codex CLI" "5:opencode:OpenCode" "6:pi:Pi Coding Agent"; do
 			num="${ai_item%%:*}"; rest="${ai_item#*:}"; key="${rest%%:*}"; label="${rest#*:}"
 			if [[ ",$ai_prev," == *",${key},"* ]]; then
 				echo "  ${num}) ${label} [installed]"
@@ -562,13 +560,13 @@ if $INTERACTIVE; then
 				echo "  ${num}) ${label}"
 			fi
 		done
-		read -rp "Selection [1-7/all/skip]: " ai_selection
+		read -rp "Selection [1-6/all/skip]: " ai_selection
 		if [ -z "$ai_selection" ] && [ -n "$ai_prev" ]; then
 			ai_choice="$ai_prev"
 		else
 			ai_choice=""
 			if [ "$ai_selection" = "all" ]; then
-				ai_choice="claude,copilot,gemini,codex,opencode,pi,paseo"
+				ai_choice="claude,copilot,gemini,codex,opencode,pi"
 			elif [ -n "$ai_selection" ]; then
 				for item in $(echo "$ai_selection" | tr ',' ' '); do
 					case "$item" in
@@ -578,7 +576,6 @@ if $INTERACTIVE; then
 						4) ai_choice="${ai_choice:+$ai_choice,}codex" ;;
 						5) ai_choice="${ai_choice:+$ai_choice,}opencode" ;;
 						6) ai_choice="${ai_choice:+$ai_choice,}pi" ;;
-					7) ai_choice="${ai_choice:+$ai_choice,}paseo" ;;
 					esac
 				done
 			fi
@@ -591,6 +588,15 @@ else
 	echo "Defaulting to Claude Code (non-interactive)"
 	ai_choice="claude"
 fi
+
+supported_ai=()
+for ai_tool in $(echo "$ai_choice" | tr ',' ' '); do
+	case "$ai_tool" in
+		claude|copilot|gemini|codex|opencode|pi) supported_ai+=("$ai_tool") ;;
+		*) echo "Warning: removing unsupported AI assistant from Selection: $ai_tool" >&2 ;;
+	esac
+done
+ai_choice=$(join_csv "${supported_ai[@]}")
 
 install_copilot() {
 	if command -v copilot &>/dev/null && { ! $SB_RERUN || $SB_RECONCILE_BOX; }; then echo "GitHub Copilot CLI already installed, skipping."; return 0; fi
@@ -621,13 +627,6 @@ install_pi() {
 	command -v pi >/dev/null 2>&1
 }
 
-install_paseo() {
-	if command -v paseo &>/dev/null && { ! $SB_RERUN || $SB_RECONCILE_BOX; }; then echo "Paseo already installed, skipping."; return 0; fi
-	ensure_node_for_npm || return 1
-	run_with_spinner "Installing/updating Paseo..." npm install -g --silent @getpaseo/cli || return 1
-	command -v paseo >/dev/null 2>&1
-}
-
 install_claude() {
 	if command -v claude >/dev/null 2>&1 && { ! $SB_RERUN || $SB_RECONCILE_BOX; }; then
 		echo "Claude Code already installed, skipping."
@@ -647,7 +646,6 @@ ai_command_present() {
 		codex) command -v codex >/dev/null 2>&1 ;;
 		opencode) command -v opencode >/dev/null 2>&1 ;;
 		pi) command -v pi >/dev/null 2>&1 ;;
-		paseo) command -v paseo >/dev/null 2>&1 ;;
 		*) return 1 ;;
 	esac
 }
@@ -676,7 +674,6 @@ for ai_tool in $(echo "$ai_choice" | tr ',' ' '); do
 		gemini)  install_gemini  && ai_ok=true ;;
 		codex)   install_codex   && ai_ok=true ;;
 		pi)      install_pi      && ai_ok=true ;;
-		paseo)   install_paseo   && ai_ok=true ;;
 	esac
 	if $ai_ok; then
 		installed_ai+=("$ai_tool")
@@ -695,7 +692,7 @@ printf '%s\n' "$ai_choice" > "$AI_CONFIG"
 # Set aliases based on selection — c maps to first selected tool in priority order
 {
 	c_target=""
-	for ai_tool in claude copilot gemini codex opencode pi paseo; do
+	for ai_tool in claude copilot gemini codex opencode pi; do
 		if [[ ",$observed_ai," == *",$ai_tool,"* ]]; then
 			[ -z "$c_target" ] && c_target="$ai_tool"
 			case "$ai_tool" in

--- a/tests/test-provision-state.sh
+++ b/tests/test-provision-state.sh
@@ -122,6 +122,18 @@ assert_true "grep -qx 'set -g mouse on' '$HOME_DIR/.config/tmux/tmux.conf'" "rec
 assert_true "[ \"\$(cat '$STATE/multiplexer')\" = tmux ]" "successful reconciliation preserves the saved Selection"
 assert_true "[ \"\$(cat '$STATE/editor-default')\" = fresh ] && grep -qx \"export EDITOR='fresh'\" '$HOME_DIR/.squarebox-editor-aliases'" "reconcile preserves a non-first default editor Selection"
 
+printf '#!/usr/bin/env bash\nexit 0\n' > "$BIN/codex"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$BIN/npm"
+chmod +x "$BIN/codex" "$BIN/npm"
+printf 'codex,removed-assistant\n' > "$STATE/ai-tool"
+if HOME="$HOME_DIR" SQUAREBOX_STATE_DIR="$STATE" \
+	SQUAREBOX_TOOL_LIB="$FIXTURE_LIB" SQUAREBOX_TOOLS_YAML=/dev/null \
+	PATH="$BIN:$PATH" bash "$ROOT/setup.sh" --rerun ai >"$TMP/reconcile-ai.out" 2>"$TMP/reconcile-ai.err"; then
+	assert_true "[ \"\$(cat '$STATE/ai-tool')\" = codex ] && grep -q 'removing unsupported AI assistant' '$TMP/reconcile-ai.err'" "reconcile removes unsupported assistants from a saved Selection"
+else
+	not_ok "reconcile removes unsupported assistants from a saved Selection"
+fi
+
 printf 'set -g mouse off\n' > "$HOME_DIR/.config/tmux/tmux.conf"
 HOME="$HOME_DIR" SQUAREBOX_STATE_DIR="$STATE" \
 	SQUAREBOX_TOOL_LIB="$FIXTURE_LIB" SQUAREBOX_TOOLS_YAML=/dev/null \

--- a/tests/test-repository-consistency.sh
+++ b/tests/test-repository-consistency.sh
@@ -14,6 +14,11 @@ if grep -E '(@githubnext/github-copilot-cli|github-copilot-cli)' \
 	fail "production surfaces still reference deprecated Copilot CLI"
 fi
 
+if grep -Eqi 'paseo' setup.sh README.md CLAUDE.md uat-checklist.md \
+	demo/setup-demo.sh scripts/squarebox-setup.sh scripts/e2e-test.sh; then
+	fail "current product surfaces still reference removed Paseo support"
+fi
+
 if grep -F 'COPY scripts/sqrbx-learn' Dockerfile >/dev/null \
 	|| grep -F 'COPY scripts/sqrbx-agent-tool-log' Dockerfile >/dev/null; then
 	fail "disabled learn implementation is still shipped"

--- a/uat-checklist.md
+++ b/uat-checklist.md
@@ -65,7 +65,7 @@ Tracking issues: [Linux desktop #99](https://github.com/SquareWaveSystems/square
 - [ ] Deliberately choose an empty Selection and confirm it is saved distinctly from cancel
 - [ ] Fail one assistant install and confirm aliases target the first successfully observed assistant
 - [ ] GitHub device authentication succeeds; decline marker and credentials survive Box replacement
-- [ ] Claude, Copilot, Gemini, Codex, OpenCode, Pi, and Paseo launch after installation
+- [ ] Claude, Copilot, Gemini, Codex, OpenCode, and Pi launch after installation
 - [ ] Copilot uses the supported `copilot` command
 - [ ] Bash initializes Starship, Zoxide, fzf keybindings/completion, aliases, and mise shims
 - [ ] Zsh and Fish initialize Starship, Zoxide, the `fzf`/`ff` command path, aliases, and mise shims


### PR DESCRIPTION
## Summary
- remove Paseo from setup, documentation, demo, and E2E selections
- filter unsupported assistants from saved Selection state during AI setup
- add regression coverage for current product surfaces and stale selections

## Test plan
- [x] Bash syntax checks
- [x] ShellCheck (error severity)
- [x] actionlint
- [x] All deterministic `tests/test-*.sh` scripts
- [ ] GitHub Actions build and image checks