### PR TITLE
fix: read git identity from XDG config when ~/.gitconfig exists

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -684,8 +684,13 @@ _git_cfg="$GIT_CONFIG_DIR/config"
 }
 _existing_name="$(git config --file "$_git_cfg" user.name 2>/dev/null || true)"
 _existing_email="$(git config --file "$_git_cfg" user.email 2>/dev/null || true)"
-_host_name="$(git config --global user.name 2>/dev/null || true)"
-_host_email="$(git config --global user.email 2>/dev/null || true)"
+# `git config --global` ignores the XDG config file whenever ~/.gitconfig
+# exists, so hosts keeping their identity under ~/.config/git/config need the
+# explicit fallback read.
+_host_name="$(git config --global user.name 2>/dev/null \
+	|| git config --file "${XDG_CONFIG_HOME:-$HOME/.config}/git/config" user.name 2>/dev/null || true)"
+_host_email="$(git config --global user.email 2>/dev/null \
+	|| git config --file "${XDG_CONFIG_HOME:-$HOME/.config}/git/config" user.email 2>/dev/null || true)"
 [ -n "${SQUAREBOX_GIT_NAME:-}" ] && _host_name="$SQUAREBOX_GIT_NAME"
 [ -n "${SQUAREBOX_GIT_EMAIL:-}" ] && _host_email="$SQUAREBOX_GIT_EMAIL"
 [ -n "$_host_name" ] || _host_name="$_existing_name"

--- a/scripts/squarebox-setup.sh
+++ b/scripts/squarebox-setup.sh
@@ -55,8 +55,15 @@ show_list() {
 
 	# Git identity
 	local git_name git_email
-	git_name=$(git config --global user.name 2>/dev/null || echo "(not set)")
-	git_email=$(git config --global user.email 2>/dev/null || echo "(not set)")
+	# `git config --global` reads only ~/.gitconfig once that file exists
+	# (gh auth setup-git creates it with credential helpers only), so also
+	# check the XDG file where setup.sh records the identity.
+	git_name=$(git config --global user.name 2>/dev/null \
+		|| git config --file "$HOME/.config/git/config" user.name 2>/dev/null \
+		|| echo "(not set)")
+	git_email=$(git config --global user.email 2>/dev/null \
+		|| git config --file "$HOME/.config/git/config" user.email 2>/dev/null \
+		|| echo "(not set)")
 	echo -e "  ${CYAN}Git identity:${RESET}     $git_name <$git_email>"
 
 	# GitHub CLI

--- a/setup.sh
+++ b/setup.sh
@@ -56,6 +56,16 @@ join_csv() {
 	echo "$*"
 }
 
+# Effective global git identity. Once ~/.gitconfig exists (gh auth setup-git
+# creates it holding only credential helpers), `git config --global <key>`
+# reads that file alone and never consults the XDG file this script writes,
+# so a configured identity would look unset. Fall back to the XDG file.
+current_git_identity() {
+	git config --global "$1" 2>/dev/null \
+		|| git config --file "$HOME/.config/git/config" "$1" 2>/dev/null \
+		|| true
+}
+
 should_run() {
 	# In first-run mode (no --rerun), always run all sections
 	$SB_RERUN || return 0
@@ -218,8 +228,8 @@ if should_run git; then
 	# be absent inside the squarebox-home volume (issue: setup fails with
 	# "could not lock config file .../.config/git/config: No such file or directory").
 	mkdir -p ~/.config/git
-	_current_name=$(git config --global user.name 2>/dev/null || true)
-	_current_email=$(git config --global user.email 2>/dev/null || true)
+	_current_name=$(current_git_identity user.name)
+	_current_email=$(current_git_identity user.email)
 
 	if $SB_RERUN && [ -n "$_current_name" ] && $INTERACTIVE; then
 		# Existing identity on re-run: present it pre-filled so you can edit

--- a/tests/test-provision-contract.sh
+++ b/tests/test-provision-contract.sh
@@ -51,5 +51,25 @@ else
 	not_ok "setup and demo describe Nano as the fallback default"
 fi
 
+# Regression: the configured git identity must stay visible after gh auth
+# setup-git creates ~/.gitconfig — `git config --global` stops consulting the
+# XDG file once ~/.gitconfig exists, so every identity reader needs the
+# explicit XDG-file fallback.
+assert grep -Fq 'git config --file "$HOME/.config/git/config" user.name' "$ROOT/scripts/squarebox-setup.sh"
+assert grep -Fq 'git config --file "$HOME/.config/git/config" user.email' "$ROOT/scripts/squarebox-setup.sh"
+assert grep -Fq 'git config --file "${XDG_CONFIG_HOME:-$HOME/.config}/git/config" user.name' "$ROOT/install.sh"
+_id_fn=$(sed -n '/^current_git_identity() {/,/^}/p' "$ROOT/setup.sh")
+_id_home=$(mktemp -d)
+mkdir -p "$_id_home/.config/git"
+printf '[user]\n\tname = XDG Name\n' >"$_id_home/.config/git/config"
+printf '[credential]\n\thelper = x\n' >"$_id_home/.gitconfig"
+if [ -n "$_id_fn" ] \
+	&& [ "$(env -u XDG_CONFIG_HOME HOME="$_id_home" bash -c "$_id_fn"$'\ncurrent_git_identity user.name')" = "XDG Name" ]; then
+	ok "setup identity read survives a credential-only ~/.gitconfig"
+else
+	not_ok "setup identity read survives a credential-only ~/.gitconfig"
+fi
+rm -rf "$_id_home"
+
 printf '1..%d\n' "$((PASS + FAIL))"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Problem

On the Unraid tower, `sqrbx-setup` showed blank git name/email prompts and `sqrbx-setup --list` reported "(not set)" even though the identity was configured. Root cause: once `gh auth setup-git` creates `~/.gitconfig` (holding only credential helpers), `git config --global user.name` reads that file alone and stops consulting `~/.config/git/config` — the XDG file where setup records the identity. Reproduced on git 2.43 (in-Box) and 2.54.

## Fix

- `setup.sh`: new `current_git_identity()` helper — `git config --global` first (so a real `~/.gitconfig` identity keeps precedence), falling back to a direct read of `~/.config/git/config`; the rerun prefill uses it.
- `scripts/squarebox-setup.sh`: same fallback in `--list`.
- `install.sh`: same fallback for host-side seeding (a host with `~/.gitconfig` plus an XDG-file identity hits the identical gotcha).
- `tests/test-provision-contract.sh`: regression test with a credential-only `~/.gitconfig` alongside an XDG identity, plus contract greps.

## Verification

- Full unit suite passes (27/27 in test-provision-contract.sh).
- Fallback command verified against the actual broken state inside the tower's container — returns the configured identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)