### PR TITLE
fix: zellij session must detach, not quit, when the client dies

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1105,16 +1105,21 @@ _install_zellij_inner() {
 		            };
 		        }
 
-		        // Prefix-style bindings via Ctrl+Space (tmux-like leader)
+		        // Prefix-style bindings via Ctrl+Space (tmux-like leader).
+		        // Ctrl+b as well: Ctrl+Space is a NUL byte some clients never
+		        // deliver (iPadOS grabs it for input-source switching)
 		        bind "Ctrl Space" { SwitchToMode "Tmux"; }
+		        bind "Ctrl b" { SwitchToMode "Tmux"; }
 		    }
 
 		    locked {
 		        bind "Ctrl Space" { SwitchToMode "Normal"; }
+		        bind "Ctrl b" { SwitchToMode "Normal"; }
 		    }
 
 		    tmux {
 		        bind "Ctrl Space" { SwitchToMode "Normal"; }
+		        bind "Ctrl b" { SwitchToMode "Normal"; }
 		        bind "Esc" { SwitchToMode "Normal"; }
 
 		        // Pane splitting (h=horizontal, v=vertical — matching tmux)
@@ -1222,6 +1227,7 @@ _install_zellij_inner() {
 		    // Allow Ctrl+Space to return to normal from any non-normal mode
 		    shared_except "normal" "locked" "tmux" {
 		        bind "Ctrl Space" { SwitchToMode "Normal"; }
+		        bind "Ctrl b" { SwitchToMode "Normal"; }
 		    }
 		}
 		ZELLIJCONF
@@ -1247,6 +1253,10 @@ _ensure_zellij_defaults() {
 	sed -i 's/^on_force_close "quit"/on_force_close "detach"/' "$conf"
 	if ! grep -q 'bind "?"' "$conf"; then
 		sed -i '/bind "\[" { SwitchToMode "Scroll"; }/a\        bind "?" { LaunchOrFocusPlugin "configuration" { floating true; }; SwitchToMode "Normal"; }' "$conf"
+	fi
+	if ! grep -q 'bind "Ctrl b" { SwitchToMode "Tmux"; }' "$conf"; then
+		sed -i 's|^\(\s*\)bind "Ctrl Space" { SwitchToMode "Tmux"; }$|&\n\1bind "Ctrl b" { SwitchToMode "Tmux"; }|' "$conf"
+		sed -i 's|^\(\s*\)bind "Ctrl Space" { SwitchToMode "Normal"; }$|&\n\1bind "Ctrl b" { SwitchToMode "Normal"; }|' "$conf"
 	fi
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -1023,7 +1023,9 @@ _install_zellij_inner() {
 		scroll_buffer_size 50000
 		pane_frames false
 		auto_layout true
-		on_force_close "quit"
+		// "detach" not "quit" — a dropped client (ssh/mosh dying) must not kill
+		// the session and everything running in it
+		on_force_close "detach"
 		simplified_ui true
 		session_serialization true
 		support_kitty_keyboard_protocol true
@@ -1161,6 +1163,9 @@ _install_zellij_inner() {
 
 		        // Enter scroll/copy mode (vi-style — like tmux [ )
 		        bind "[" { SwitchToMode "Scroll"; }
+
+		        // Keybinding help — floating configuration plugin
+		        bind "?" { LaunchOrFocusPlugin "configuration" { floating true; }; SwitchToMode "Normal"; }
 		    }
 
 		    // ── Scroll mode (vi-style copy mode) ────────────────────────
@@ -1236,9 +1241,19 @@ _install_zellij_inner() {
 	fi
 }
 
+_ensure_zellij_defaults() {
+	local conf="$HOME/.config/zellij/config.kdl"
+	[ -f "$conf" ] || return 0
+	sed -i 's/^on_force_close "quit"/on_force_close "detach"/' "$conf"
+	if ! grep -q 'bind "?"' "$conf"; then
+		sed -i '/bind "\[" { SwitchToMode "Scroll"; }/a\        bind "?" { LaunchOrFocusPlugin "configuration" { floating true; }; SwitchToMode "Normal"; }' "$conf"
+	fi
+}
+
 install_zellij() {
-	if command -v zellij &>/dev/null; then echo "Zellij already installed, skipping."; return 0; fi
+	if command -v zellij &>/dev/null; then echo "Zellij already installed, skipping."; _ensure_zellij_defaults; return 0; fi
 	run_with_spinner "Installing Zellij..." _install_zellij_inner
+	_ensure_zellij_defaults
 }
 
 for mux in $(echo "$mux_list" | tr ',' ' '); do


### PR DESCRIPTION
## What

- `on_force_close "quit"` → `"detach"` in the default zellij config. With `quit`, any dropped client connection (ssh timeout, mosh client killed, terminal app closed by the OS) killed the entire session and every process running in it — the opposite of what a terminal multiplexer is for. `detach` (zellij's own default) leaves the session running for reattach.
- `Ctrl+b` as a second leader mirroring every `Ctrl+Space` mode bind. Ctrl+Space is a NUL byte some client stacks never deliver (iPadOS grabs it for input-source switching before the terminal app sees it); Ctrl+b is the classic tmux prefix. Scroll/search keep their explicit Ctrl+b page-up binds, which take precedence over the shared exit bind.
- New `_ensure_zellij_defaults` self-heal (same pattern as the tmux mouse self-heal) so already-provisioned containers get all fixes on the next setup run, since the config heredoc only writes when no `config.kdl` exists.
- Bind `<leader> ?` to a floating configuration plugin as a keybinding help popup — `clear-defaults=true` means there is otherwise no discoverable way to browse the custom binds.

## Testing

- `bash -n setup.sh`
- Fresh-install path: heredoc extracted and validated with `zellij setup --check` (zellij 0.44.3, in a live squarebox container).
- Upgrade path: `_ensure_zellij_defaults` run verbatim against a pre-fix `config.kdl`; result has the 4 expected Ctrl+b binds and passes `zellij setup --check`.
- Detach-on-disconnect, `?` popup, and Ctrl+b leader confirmed interactively over mosh from an iPad (Blink) client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)