### PR TITLE
feat: ship bubblewrap in the base image for the Codex CLI sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Added
+
+- `bubblewrap` in the base image so the OpenAI Codex CLI uses the system
+  `bwrap` for its Linux sandbox instead of warning and falling back to its
+  bundled helper.
+
 ### Removed
 
 - Paseo assistant installation and Selection support.

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,9 @@ RUN printf 'path-include=/usr/share/doc/fzf/examples/key-bindings.bash\n' \
 	nano \
 	zstd \
 	zoxide \
+	# bubblewrap: OpenAI Codex CLI's Linux sandbox uses the first bwrap on PATH
+	# and warns at startup when only its bundled fallback helper is available.
+	bubblewrap \
 	toilet \
 	toilet-fonts \
 	libicu-dev \

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ What's included
 | Name | Language | Description |
 |------|----------|-------------|
 | [bat](https://github.com/sharkdp/bat) | Rust | Cat clone with syntax highlighting |
+| [bubblewrap](https://github.com/containers/bubblewrap) | C | Unprivileged sandboxing tool (`bwrap`), used by the Codex CLI sandbox |
 | [curl](https://github.com/curl/curl) | C | URL data transfer |
 | [delta](https://github.com/dandavison/delta) | Rust | Syntax-highlighting pager for git diffs |
 | [difftastic](https://github.com/Wilfred/difftastic) | Rust | Syntax-aware structural diff tool (`difft`) |

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -72,7 +72,7 @@ suite_tools() {
 	# Candidate suite so publication cannot depend on the separate PR workflow.
 	local command_name
 	local -a core_commands=(
-		bat curl delta difft eza fd fzf gh glow gum jq just mise nano rg
+		bat bwrap curl delta difft eza fd fzf gh glow gum jq just mise nano rg
 		starship xh yq zoxide
 	)
 	for command_name in "${core_commands[@]}"; do


### PR DESCRIPTION
## Why

The OpenAI Codex CLI's Linux sandbox uses the first `bwrap` executable it finds on `PATH`. When none exists it warns at startup (`⚠ Codex could not find system bubblewrap at /usr/bin/bwrap`) and falls back to a bundled helper that still depends on unprivileged user-namespace support. Upstream's recommended setup is to install the distribution's `bubblewrap` package ([Codex sandboxing docs](https://developers.openai.com/codex/concepts/sandboxing), [openai/codex#14963](https://github.com/openai/codex/pull/14963)).

## What

- **Dockerfile**: add `bubblewrap` to the base APT package layer, with a comment recording the Codex rationale.
- **scripts/e2e-test.sh**: add `bwrap` to the always-present core command inventory so the Candidate suite gates on it.
- **README.md**: document bubblewrap in the CLI tools table.
- **CHANGELOG.md**: note the addition under Unreleased.

## Placement rationale

Image tier rather than Box tier: assistants install into the Managed home (mise-managed Node, npm globals), so after Box replacement `--reconcile-box` skips `install_codex` when the `codex` binary survives — a Box-tier `apt_install bubblewrap` hung off that path would silently go missing on every Box replacement. Shipping it in the image keeps `bwrap` present unconditionally with no reconcile logic, at ~1 MB of image cost, and it benefits any Codex selection made at any time.

## Validation

- All 17 local `tests/test-*.sh` suites pass.
- Docker is unavailable in this session; the image build and `e2e-test.sh smoke` (which now asserts `bwrap` presence via `tools.core.bwrap`) run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GiQdQXNUM2Wca7VcWrByhS

---
_Generated by [Claude Code](https://claude.ai/code/session_01GiQdQXNUM2Wca7VcWrByhS)_