### PR TITLE
feat: add herdr agent multiplexer as a selectable multiplexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - `bubblewrap` in the base image so the OpenAI Codex CLI uses the system
   `bwrap` for its Linux sandbox instead of warning and falling back to its
   bundled helper.
+- Herdr is available as a selectable agent multiplexer, installed from its
+  verified GitHub release asset into the Managed home.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ scripted installs). Values use the same keys as `sqrbx-setup`:
 | `SQUAREBOX_SDKS` | language SDKs (`node,python,go,dotnet,rust`) |
 | `SQUAREBOX_EDITORS` | editors (`micro,edit,fresh,helix,nvim`; Helix launches as `hx`) |
 | `SQUAREBOX_TUIS` | TUI tools (`lazygit,gh-dash,yazi`) |
-| `SQUAREBOX_MULTIPLEXERS` | multiplexers (`tmux,zellij`) |
+| `SQUAREBOX_MULTIPLEXERS` | multiplexers (`tmux,zellij,herdr`) |
 | `SQUAREBOX_GIT_NAME` / `SQUAREBOX_GIT_EMAIL` | git identity (when no host gitconfig) |
 
 Example:
@@ -286,12 +286,13 @@ Installed during first-run setup. Choose any combination:
 
 ### Terminal Multiplexers
 
-Installed during first-run setup. Choose either, both, or neither:
+Installed during first-run setup. Choose any combination, or none:
 
 | Name | Description |
 |------|-------------|
 | [tmux](https://github.com/tmux/tmux) | Classic terminal multiplexer |
 | [zellij](https://github.com/zellij-org/zellij) | Friendly terminal workspace |
+| [herdr](https://herdr.dev) | Agent multiplexer — run multiple coding agents from one terminal |
 
 ### Shell (Experimental)
 

--- a/demo/setup-demo.sh
+++ b/demo/setup-demo.sh
@@ -100,13 +100,14 @@ echo
 section_header "Terminal Multiplexers"
 selected=$(gum choose --no-limit \
     --header "Select terminal multiplexer:" \
-    "tmux" "zellij") || true
+    "tmux" "zellij" "herdr") || true
 
 while IFS= read -r line; do
     [ -z "$line" ] && continue
     case "$line" in
         tmux)   run_with_spinner "Installing tmux..." 0.6 ;;
         zellij) run_with_spinner "Installing Zellij..." 0.6 ;;
+        herdr)  run_with_spinner "Installing Herdr..." 0.6 ;;
     esac
 done <<< "$selected"
 

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -227,7 +227,7 @@ suite_setup_editors() {
 	echo "opencode,pi" > /workspace/.squarebox/ai-tool
 	echo "micro,edit,fresh,helix,nvim" > /workspace/.squarebox/editors
 	echo "lazygit,gh-dash,yazi" > /workspace/.squarebox/tuis
-	echo "tmux,zellij" > /workspace/.squarebox/multiplexer
+	echo "tmux,zellij,herdr" > /workspace/.squarebox/multiplexer
 	echo "node,go" > /workspace/.squarebox/sdks
 	# Shell section (experimental): exercise the bash path here. The zsh
 	# install (apt zsh + Oh My Zsh + two plugin clones) is network-heavy and
@@ -278,6 +278,7 @@ suite_setup_editors() {
 	# 3.8 multiplexers installed
 	run_test "3.8a tmux installed" command -v tmux
 	run_test "3.8b zellij installed" command -v zellij
+	run_test "3.8c herdr installed" command -v herdr
 
 	# 3.9 SDKs installed (via mise)
 	run_test "3.9a node installed (via mise)" command -v node

--- a/scripts/lib/tools.yaml
+++ b/scripts/lib/tools.yaml
@@ -230,3 +230,13 @@ tools:
     dest: user
     group: setup
     verification: github-release-digest
+
+  herdr:
+    repo: ogulcancelik/herdr
+    version_prefix: v
+    artifact: herdr-linux-{zarch}
+    method: binary
+    binaries: herdr
+    dest: user
+    group: setup
+    verification: github-release-digest

--- a/scripts/lib/tools.yaml
+++ b/scripts/lib/tools.yaml
@@ -232,7 +232,7 @@ tools:
     verification: github-release-digest
 
   herdr:
-    repo: ogulcancelik/herdr
+    repo: herdrdev/herdr
     version_prefix: v
     artifact: herdr-linux-{zarch}
     method: binary

--- a/scripts/sqrbx-learn
+++ b/scripts/sqrbx-learn
@@ -83,7 +83,7 @@ has_tool() {
 	case "$tool" in
 		lazygit|gh-dash|yazi)
 			grep -qw "$tool" "$SQUAREBOX_DIR/tuis" 2>/dev/null ;;
-		tmux|zellij)
+		tmux|zellij|herdr)
 			grep -qw "$tool" "$SQUAREBOX_DIR/multiplexer" 2>/dev/null ;;
 		*)
 			command -v "$tool" &>/dev/null ;;

--- a/scripts/squarebox-setup.sh
+++ b/scripts/squarebox-setup.sh
@@ -34,7 +34,7 @@ usage() {
 	  ai             AI coding assistants (claude, copilot, gemini, codex, opencode, pi)
 	  editors        Text editors (micro, edit, fresh, helix/hx, nvim)
 	  tuis           TUI tools (lazygit, gh-dash, yazi)
-	  multiplexers   Terminal multiplexers (tmux, zellij)
+	  multiplexers   Terminal multiplexers (tmux, zellij, herdr)
 	  sdks           SDKs (node, python, go, dotnet, rust)
 	  shell          Default shell (bash, zsh/fish — experimental)
 

--- a/scripts/squarebox-update.sh
+++ b/scripts/squarebox-update.sh
@@ -304,6 +304,7 @@ helix_current() { hx --version 2>/dev/null | _extract_first_version; }
 nvim_current() { nvim --version 2>/dev/null | _extract_first_version; }
 opencode_current() { opencode --version 2>/dev/null | _extract_first_version; }
 zellij_current() { zellij --version 2>/dev/null | _extract_first_version; }
+herdr_current() { herdr --version 2>/dev/null | _extract_first_version; }
 just_current() { just --version 2>/dev/null | _extract_first_version; }
 difftastic_current() { difft --version 2>/dev/null | _extract_first_version; }
 mise_current() { mise --version 2>/dev/null | _extract_first_version; }

--- a/setup.sh
+++ b/setup.sh
@@ -1212,12 +1212,13 @@ if $INTERACTIVE; then
 			case "$mux" in
 				tmux)   gum_selected="${gum_selected:+$gum_selected,}tmux" ;;
 				zellij) gum_selected="${gum_selected:+$gum_selected,}zellij" ;;
+				herdr)  gum_selected="${gum_selected:+$gum_selected,}herdr" ;;
 			esac
 		done
 		gum_args=(--no-limit --header "Select terminal multiplexer:")
 		[ -n "$gum_selected" ] && gum_args+=(--selected "$gum_selected")
 		if ! selected=$(gum choose "${gum_args[@]}" \
-			"tmux" "zellij"); then
+			"tmux" "zellij" "herdr"); then
 			cancel_setup
 		fi
 		mux_list=""
@@ -1227,7 +1228,7 @@ if $INTERACTIVE; then
 		done <<< "$selected"
 	else
 		echo "Select terminal multiplexer (comma-separated, or 'all', or press Enter to skip):"
-		for mux_item in "1:tmux:classic terminal multiplexer" "2:zellij:friendly terminal workspace"; do
+		for mux_item in "1:tmux:classic terminal multiplexer" "2:zellij:friendly terminal workspace" "3:herdr:agent multiplexer for coding agents"; do
 			num="${mux_item%%:*}"; rest="${mux_item#*:}"; key="${rest%%:*}"; desc="${rest#*:}"
 			if [[ ",$mux_prev," == *",${key},"* ]]; then
 				echo "  ${num}) ${key} — ${desc} [installed]"
@@ -1235,18 +1236,19 @@ if $INTERACTIVE; then
 				echo "  ${num}) ${key} — ${desc}"
 			fi
 		done
-		read -rp "Selection [1,2/all/skip]: " mux_selection
+		read -rp "Selection [1,2,3/all/skip]: " mux_selection
 		if [ -z "$mux_selection" ] && [ -n "$mux_prev" ]; then
 			mux_list="$mux_prev"
 		else
 			mux_list=""
 			if [ "$mux_selection" = "all" ]; then
-				mux_list="tmux,zellij"
+				mux_list="tmux,zellij,herdr"
 			elif [ -n "$mux_selection" ]; then
 				for item in $(echo "$mux_selection" | tr ',' ' '); do
 					case "$item" in
 						1) mux_list="${mux_list:+$mux_list,}tmux" ;;
 						2) mux_list="${mux_list:+$mux_list,}zellij" ;;
+						3) mux_list="${mux_list:+$mux_list,}herdr" ;;
 					esac
 				done
 			fi
@@ -1650,6 +1652,19 @@ install_zellij() {
 	run_with_spinner "Installing Zellij..." _install_zellij_inner
 }
 
+_install_herdr_inner() {
+	command -v herdr >/dev/null 2>&1 || sb_install herdr latest || return 1
+	command -v herdr >/dev/null 2>&1 || return 1
+}
+
+install_herdr() {
+	if command -v herdr &>/dev/null; then
+		echo "Herdr already installed, skipping."
+		return 0
+	fi
+	run_with_spinner "Installing Herdr..." _install_herdr_inner
+}
+
 installed_mux=()
 committed_mux=()
 for mux in $(echo "$mux_list" | tr ',' ' '); do
@@ -1666,6 +1681,13 @@ for mux in $(echo "$mux_list" | tr ',' ' '); do
 			else
 				record_failure "Zellij installation failed; new Selection was not committed"
 				[[ ",$mux_prev," == *",zellij,"* ]] && committed_mux+=("zellij")
+			fi
+			;;
+		herdr)
+			if install_herdr; then installed_mux+=("herdr"); committed_mux+=("herdr")
+			else
+				record_failure "Herdr installation failed; new Selection was not committed"
+				[[ ",$mux_prev," == *",herdr,"* ]] && committed_mux+=("herdr")
 			fi
 			;;
 	esac

--- a/tests/test-provision-install-failures.sh
+++ b/tests/test-provision-install-failures.sh
@@ -158,6 +158,13 @@ assert_true "[ ! -e '$ZELLIJ_CASE/home/.config/zellij/config.kdl' ]" \
 assert_true "grep -qx 'zellij latest' '$ZELLIJ_CASE/sb-install.calls'" \
 	"Zellij regression exercises the sb_install seam"
 
+HERDR_CASE="$TMP/herdr"
+run_selected_section multiplexers herdr "$HERDR_CASE"
+assert_true "[ \"\$(cat '$HERDR_CASE/setup.rc')\" -ne 0 ] && [ -z \"\$(cat '$HERDR_CASE/state/multiplexer')\" ]" \
+	"Herdr sb_install failure propagates without committing a Selection"
+assert_true "grep -qx 'herdr latest' '$HERDR_CASE/sb-install.calls'" \
+	"Herdr failure audit exercises its sb_install caller"
+
 # Audit every adjacent setup-tier sb_install caller, not just the two callers
 # that originally had a successful config write after the failed install.
 EDITORS_CASE="$TMP/editors"

--- a/uat-checklist.md
+++ b/uat-checklist.md
@@ -73,6 +73,7 @@ Qualification issues: [Linux desktop #126](https://github.com/SquareWaveSystems/
 - [ ] Section-only AI/editor/TUI reruns refresh Fish derived configuration
 - [ ] A non-first default editor survives Box replacement and noninteractive reconciliation
 - [ ] Explicit `set -g mouse off` remains respected during tmux migration
+- [ ] Herdr launches after installation and survives Box replacement from the Managed home
 
 ## Interactive tools
 


### PR DESCRIPTION
Wire Herdr (https://herdr.dev, `herdrdev/herdr`) into the tool registry
and the multiplexers section alongside tmux and Zellij.

- `tools.yaml`: setup-tier binary entry for `herdr-linux-{zarch}`, installed
  to the Managed home with the exact GitHub release-asset digest.
- `setup.sh`: interactive, gum, and noninteractive Selection support with
  observed-binary commit semantics.
- Updater, help, README, demo, and E2E coverage.
- Failure-path regression coverage proving a rejected install cannot commit
  stale Selection state.
- v1.2 changelog and UAT coverage.

Herdr is a Managed-home binary like Zellij, so it survives Box replacement and
does not need entrypoint reconciliation.

Validation:

- Every executable `tests/test-*.sh` script
- `repository-tests`
- amd64 image build
- arm64 image build

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012aoxvEh7tFvkMqtGUGDvVg
