### PR TITLE
feat: add elio as a selectable TUI file manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - `bubblewrap` in the base image so the OpenAI Codex CLI uses the system
   `bwrap` for its Linux sandbox instead of warning and falling back to its
   bundled helper.
+- `elio` as a selectable TUI file manager alongside Yazi, installed from its
+  verified GitHub release asset into the Managed home.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ scripted installs). Values use the same keys as `sqrbx-setup`:
 | `SQUAREBOX_AI` | AI assistants (`claude,copilot,gemini,codex,opencode,pi`) |
 | `SQUAREBOX_SDKS` | language SDKs (`node,python,go,dotnet,rust`) |
 | `SQUAREBOX_EDITORS` | editors (`micro,edit,fresh,helix,nvim`; Helix launches as `hx`) |
-| `SQUAREBOX_TUIS` | TUI tools (`lazygit,gh-dash,yazi`) |
+| `SQUAREBOX_TUIS` | TUI tools (`lazygit,gh-dash,yazi,elio`) |
 | `SQUAREBOX_MULTIPLEXERS` | multiplexers (`tmux,zellij`) |
 | `SQUAREBOX_GIT_NAME` / `SQUAREBOX_GIT_EMAIL` | git identity (when no host gitconfig) |
 
@@ -283,6 +283,7 @@ Installed during first-run setup. Choose any combination:
 | [lazygit](https://github.com/jesseduffield/lazygit) | Go | Git terminal UI |
 | [gh-dash](https://github.com/dlvhdr/gh-dash) | Go | GitHub dashboard for the terminal |
 | [yazi](https://github.com/sxyazi/yazi) | Rust | Terminal file manager |
+| [elio](https://github.com/elio-fm/elio) | Rust | Terminal file manager with rich previews, inline images, and trash support |
 
 ### Terminal Multiplexers
 
@@ -472,6 +473,7 @@ First-run selections add to that:
 | OpenCode | ~30 MB |
 | Pi Coding Agent | ~50 MB |
 | lazygit / gh-dash / yazi | ~10 / ~10 / ~10 MB |
+| elio | ~14 MB |
 | micro / edit | ~12 / ~7 MB |
 | fresh / nvim | ~10 / ~45 MB |
 | Helix | Varies by release (binary plus runtime files) |
@@ -529,7 +531,7 @@ container environment variables (set to an empty string to opt out of a tier):
 | `SQUAREBOX_DC_AI` | `claude` | AI assistants (`claude,copilot,gemini,codex,opencode,pi`) |
 | `SQUAREBOX_DC_SDKS` | `node` | SDKs (`node,python,go,dotnet,rust`) |
 | `SQUAREBOX_DC_EDITORS` | _(none)_ | Editors (`micro,edit,fresh,helix,nvim`; Helix launches as `hx`) |
-| `SQUAREBOX_DC_TUIS` | _(none)_ | TUI tools (`lazygit,gh-dash,yazi`) |
+| `SQUAREBOX_DC_TUIS` | _(none)_ | TUI tools (`lazygit,gh-dash,yazi,elio`) |
 
 To add or change tools after the fact, run `sqrbx-setup` from the integrated
 terminal.

--- a/demo/setup-demo.sh
+++ b/demo/setup-demo.sh
@@ -88,7 +88,7 @@ echo
 section_header "TUI Tools"
 selected=$(gum choose --no-limit \
     --header "Select terminal tools to install:" \
-    "lazygit" "gh-dash" "yazi") || true
+    "lazygit" "gh-dash" "yazi" "elio") || true
 
 while IFS= read -r line; do
     [ -z "$line" ] && continue

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -226,7 +226,7 @@ suite_setup_editors() {
 	mkdir -p /workspace/.squarebox
 	echo "opencode,pi" > /workspace/.squarebox/ai-tool
 	echo "micro,edit,fresh,helix,nvim" > /workspace/.squarebox/editors
-	echo "lazygit,gh-dash,yazi" > /workspace/.squarebox/tuis
+	echo "lazygit,gh-dash,yazi,elio" > /workspace/.squarebox/tuis
 	echo "tmux,zellij" > /workspace/.squarebox/multiplexer
 	echo "node,go" > /workspace/.squarebox/sdks
 	# Shell section (experimental): exercise the bash path here. The zsh
@@ -271,6 +271,7 @@ suite_setup_editors() {
 	run_test "3.7h gh-dash installed" command -v gh-dash
 	run_test "3.7i yazi installed" command -v yazi
 	run_test "3.7j ya installed" command -v ya
+	run_test "3.7k elio installed" command -v elio
 
 	# 5.12 lazygit config uses delta pager (set up by install_lazygit)
 	run_test_grep "5.12 lazygit config uses delta" "delta" cat /home/dev/.config/lazygit/config.yml

--- a/scripts/lib/tools.yaml
+++ b/scripts/lib/tools.yaml
@@ -150,6 +150,17 @@ tools:
     group: setup
     verification: github-release-digest
 
+  elio:
+    repo: elio-fm/elio
+    version_prefix: v
+    artifact: elio-{version}-{zarch}-unknown-linux-gnu.tar.gz
+    method: tar.gz
+    binaries: elio
+    tar_strip: 1
+    dest: user
+    group: setup
+    verification: github-release-digest
+
   opencode:
     repo: anomalyco/opencode
     version_prefix: v

--- a/scripts/squarebox-setup.sh
+++ b/scripts/squarebox-setup.sh
@@ -33,7 +33,7 @@ usage() {
 	  github         GitHub CLI authentication
 	  ai             AI coding assistants (claude, copilot, gemini, codex, opencode, pi)
 	  editors        Text editors (micro, edit, fresh, helix/hx, nvim)
-	  tuis           TUI tools (lazygit, gh-dash, yazi)
+	  tuis           TUI tools (lazygit, gh-dash, yazi, elio)
 	  multiplexers   Terminal multiplexers (tmux, zellij)
 	  sdks           SDKs (node, python, go, dotnet, rust)
 	  shell          Default shell (bash, zsh/fish — experimental)

--- a/scripts/squarebox-update.sh
+++ b/scripts/squarebox-update.sh
@@ -294,6 +294,7 @@ lazygit_current() {
 }
 xh_current() { xh --version 2>/dev/null | _extract_first_version; }
 yazi_current() { yazi --version 2>/dev/null | _extract_first_version; }
+elio_current() { elio --version 2>/dev/null | _extract_first_version; }
 starship_current() { starship --version 2>/dev/null | _extract_first_version; }
 ghdash_current() { gh-dash --version 2>/dev/null | _extract_first_version; }
 glow_current() { glow --version 2>/dev/null | _extract_first_version; }

--- a/setup.sh
+++ b/setup.sh
@@ -1072,12 +1072,13 @@ if $INTERACTIVE; then
 				lazygit) gum_selected="${gum_selected:+$gum_selected,}lazygit" ;;
 				gh-dash) gum_selected="${gum_selected:+$gum_selected,}gh-dash" ;;
 				yazi)    gum_selected="${gum_selected:+$gum_selected,}yazi" ;;
+				elio)    gum_selected="${gum_selected:+$gum_selected,}elio" ;;
 			esac
 		done
 		gum_args=(--no-limit --header "Select TUI tools to install:")
 		[ -n "$gum_selected" ] && gum_args+=(--selected "$gum_selected")
 		if ! selected=$(gum choose "${gum_args[@]}" \
-			"lazygit" "gh-dash" "yazi"); then
+			"lazygit" "gh-dash" "yazi" "elio"); then
 			cancel_setup
 		fi
 		tui_list=""
@@ -1087,7 +1088,7 @@ if $INTERACTIVE; then
 		done <<< "$selected"
 	else
 		echo "Select TUI tools to install (comma-separated, or 'all', or press Enter to skip):"
-		for tui_item in "1:lazygit:git terminal UI" "2:gh-dash:GitHub dashboard for the terminal" "3:yazi:terminal file manager"; do
+		for tui_item in "1:lazygit:git terminal UI" "2:gh-dash:GitHub dashboard for the terminal" "3:yazi:terminal file manager" "4:elio:terminal file manager with rich previews"; do
 			num="${tui_item%%:*}"; rest="${tui_item#*:}"; key="${rest%%:*}"; desc="${rest#*:}"
 			if [[ ",$tui_prev," == *",${key},"* ]]; then
 				echo "  ${num}) ${key} — ${desc} [installed]"
@@ -1095,19 +1096,20 @@ if $INTERACTIVE; then
 				echo "  ${num}) ${key} — ${desc}"
 			fi
 		done
-		read -rp "Selection [1,2,3/all/skip]: " tui_selection
+		read -rp "Selection [1,2,3,4/all/skip]: " tui_selection
 		if [ -z "$tui_selection" ] && [ -n "$tui_prev" ]; then
 			tui_list="$tui_prev"
 		else
 			tui_list=""
 			if [ "$tui_selection" = "all" ]; then
-				tui_list="lazygit,gh-dash,yazi"
+				tui_list="lazygit,gh-dash,yazi,elio"
 			elif [ -n "$tui_selection" ]; then
 				for item in $(echo "$tui_selection" | tr ',' ' '); do
 					case "$item" in
 						1) tui_list="${tui_list:+$tui_list,}lazygit" ;;
 						2) tui_list="${tui_list:+$tui_list,}gh-dash" ;;
 						3) tui_list="${tui_list:+$tui_list,}yazi" ;;
+						4) tui_list="${tui_list:+$tui_list,}elio" ;;
 					esac
 				done
 			fi
@@ -1163,6 +1165,12 @@ install_yazi() {
 	command -v yazi >/dev/null 2>&1 && command -v ya >/dev/null 2>&1
 }
 
+install_elio() {
+	if command -v elio &>/dev/null; then echo "elio already installed, skipping."; return 0; fi
+	run_with_spinner "Installing elio..." sb_install elio latest || return 1
+	command -v elio >/dev/null 2>&1
+}
+
 installed_tuis=()
 committed_tuis=()
 for tui in $(echo "$tui_list" | tr ',' ' '); do
@@ -1176,6 +1184,9 @@ for tui in $(echo "$tui_list" | tr ',' ' '); do
 		yazi)
 			if install_yazi; then installed_tuis+=("yazi"); committed_tuis+=("yazi")
 			else record_failure "Yazi installation failed; new Selection was not committed"; [[ ",$tui_prev," == *",yazi,"* ]] && committed_tuis+=("yazi"); fi ;;
+		elio)
+			if install_elio; then installed_tuis+=("elio"); committed_tuis+=("elio")
+			else record_failure "elio installation failed; new Selection was not committed"; [[ ",$tui_prev," == *",elio,"* ]] && committed_tuis+=("elio"); fi ;;
 	esac
 done
 tui_list=$(join_csv "${committed_tuis[@]}")

--- a/tests/test-provision-install-failures.sh
+++ b/tests/test-provision-install-failures.sh
@@ -170,10 +170,10 @@ for editor in micro edit fresh helix nvim; do
 done
 
 TUIS_CASE="$TMP/tuis"
-run_selected_section tuis $'lazygit\ngh-dash\nyazi' "$TUIS_CASE"
+run_selected_section tuis $'lazygit\ngh-dash\nyazi\nelio' "$TUIS_CASE"
 assert_true "[ \"\$(cat '$TUIS_CASE/setup.rc')\" -ne 0 ] && [ -z \"\$(cat '$TUIS_CASE/state/tuis')\" ]" \
 	"all TUI sb_install failures propagate without committing Selections"
-for tui in lazygit gh-dash yazi; do
+for tui in lazygit gh-dash yazi elio; do
 	assert_true "grep -qx '$tui latest' '$TUIS_CASE/sb-install.calls'" \
 		"$tui failure audit exercises its sb_install caller"
 done

--- a/uat-checklist.md
+++ b/uat-checklist.md
@@ -75,7 +75,7 @@ Tracking issues: [Linux desktop #99](https://github.com/SquareWaveSystems/square
 
 ## Interactive tools
 
-- [ ] `lazygit`, `yazi`, `gh-dash`, and Helix (`hx`) render and accept input
+- [ ] `lazygit`, `yazi`, `elio`, `gh-dash`, and Helix (`hx`) render and accept input
 - [ ] `gum` and `fzf` interactive modes work with the host terminal
 - [ ] tmux and Zellij keybindings match the documentation
 - [ ] Neovim/LazyVim first launch completes without wedging dpkg under the timezone mount


### PR DESCRIPTION
elio (elio-fm/elio) is a Rust terminal file manager with rich previews,
inline images, bulk actions, and trash support. It joins Yazi as a second
file-manager option in the `tuis` Selection tier.

Registry entry is setup-tier/user-dest with github-release-digest
verification, installing the single `elio` binary from the upstream
`elio-{version}-{zarch}-unknown-linux-gnu.tar.gz` release asset.

Wiring: gum and numbered setup prompts (including the `all` list and
previous-Selection restore), install_elio with observed-binary commit
semantics, the updater version probe, the setup wrapper's section help,
the demo, e2e seeding plus an installed-binary assertion, the install
failure audit, and the README/UAT/CHANGELOG entries.

Verified the resolved asset URL, digest gate, extraction, and promotion
by running sb_install against the real upstream release, and confirmed
sqrbx-update probes the installed version. Full tests/ suite passes.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NgkW7jhB1frZqPmjJZugiz