### PR TITLE
Add Oh My Pi coding harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - `bubblewrap` in the base image so the OpenAI Codex CLI uses the system
   `bwrap` for its Linux sandbox instead of warning and falling back to its
   bundled helper.
+- Oh My Pi (`omp`) is available as a selectable coding harness, installed and
+  managed through mise in the persistent Managed home.
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ GitHub authentication uses the normal Managed-home `~/.config/gh` plus
 `~/.squarebox-gh-skip`; legacy Workspace markers are migrated.
 
 Supported assistant keys include `claude`, `copilot`, `gemini`, `codex`,
-`opencode`, and `pi`. Copilot is `@github/copilot`, binary `copilot`,
+`opencode`, `pi`, and `omp`. Copilot is `@github/copilot`, binary `copilot`,
 and needs Node 22 or newer. SDKs are managed by mise. Editors include micro,
 edit, fresh, Helix (`hx`), and Neovim/LazyVim.
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ scripted installs). Values use the same keys as `sqrbx-setup`:
 
 | Variable | Selects |
 |----------|---------|
-| `SQUAREBOX_AI` | AI assistants (`claude,copilot,gemini,codex,opencode,pi`) |
+| `SQUAREBOX_AI` | AI assistants (`claude,copilot,gemini,codex,opencode,pi,omp`) |
 | `SQUAREBOX_SDKS` | language SDKs (`node,python,go,dotnet,rust`) |
 | `SQUAREBOX_EDITORS` | editors (`micro,edit,fresh,helix,nvim`; Helix launches as `hx`) |
 | `SQUAREBOX_TUIS` | TUI tools (`lazygit,gh-dash,yazi`) |
@@ -256,6 +256,7 @@ pre-selected non-interactively via the `SQUAREBOX_AI`/`SQUAREBOX_SDKS`/… env v
 | [OpenAI Codex CLI](https://github.com/openai/codex) | Rust | OpenAI Codex in the terminal * |
 | [opencode](https://github.com/anomalyco/opencode) | TypeScript/Bun | AI coding TUI |
 | [Pi Coding Agent](https://github.com/earendil-works/pi) | TypeScript | Minimal terminal coding harness (Earendil) * |
+| [Oh My Pi](https://github.com/can1357/oh-my-pi) | TypeScript/Rust | Batteries-included coding harness (`omp`), installed via mise |
 \* Requires Node.js (auto-installed if needed).
 
 ### Text Editors
@@ -470,6 +471,7 @@ First-run selections add to that:
 | OpenAI Codex CLI | ~50 MB |
 | OpenCode | ~30 MB |
 | Pi Coding Agent | ~50 MB |
+| Oh My Pi | Varies by release |
 | lazygit / gh-dash / yazi | ~10 / ~10 / ~10 MB |
 | micro / edit | ~12 / ~7 MB |
 | fresh / nvim | ~10 / ~45 MB |
@@ -502,7 +504,8 @@ SDKs (Node, Python, Go, .NET, Rust) are installed by [mise](https://github.com/j
 which is itself a Dockerfile-tier pinned binary. mise downloads each SDK
 toolchain from its upstream over HTTPS using its own integrity checks. npm-based
 AI tools (Copilot CLI, Gemini CLI, Codex CLI, and Pi) use npm's built-in
-integrity verification.
+integrity verification. Oh My Pi uses its official mise GitHub backend and
+follows mise's backend integrity policy.
 
 For the full trust model (what `install.sh` does on your machine, how each
 layer is verified, and how to inspect the script before running it) see
@@ -525,7 +528,7 @@ container environment variables (set to an empty string to opt out of a tier):
 
 | Variable | Default | Selects |
 |----------|---------|---------|
-| `SQUAREBOX_DC_AI` | `claude` | AI assistants (`claude,copilot,gemini,codex,opencode,pi`) |
+| `SQUAREBOX_DC_AI` | `claude` | AI assistants (`claude,copilot,gemini,codex,opencode,pi,omp`) |
 | `SQUAREBOX_DC_SDKS` | `node` | SDKs (`node,python,go,dotnet,rust`) |
 | `SQUAREBOX_DC_EDITORS` | _(none)_ | Editors (`micro,edit,fresh,helix,nvim`; Helix launches as `hx`) |
 | `SQUAREBOX_DC_TUIS` | _(none)_ | TUI tools (`lazygit,gh-dash,yazi`) |

--- a/demo/setup-demo.sh
+++ b/demo/setup-demo.sh
@@ -35,7 +35,7 @@ section_header "AI Coding Assistants"
 selected=$(gum choose --no-limit \
     --header "Select AI coding assistants (space=toggle, enter=confirm):" \
     "Claude Code" "GitHub Copilot CLI" "Google Gemini CLI" \
-    "OpenAI Codex CLI" "OpenCode" "Pi Coding Agent") || true
+    "OpenAI Codex CLI" "OpenCode" "Pi Coding Agent" "Oh My Pi") || true
 
 node_installed=false
 while IFS= read -r line; do
@@ -50,6 +50,9 @@ while IFS= read -r line; do
                 node_installed=true
             fi
             run_with_spinner "Installing ${line}..." 0.8
+            ;;
+        "Oh My Pi")
+            run_with_spinner "Installing Oh My Pi (via mise)..." 0.8
             ;;
         "OpenCode")
             run_with_spinner "Installing OpenCode..." 0.8

--- a/scripts/squarebox-setup.sh
+++ b/scripts/squarebox-setup.sh
@@ -31,7 +31,7 @@ usage() {
 	${BOLD}Sections:${RESET}
 	  git            Git identity (name, email)
 	  github         GitHub CLI authentication
-	  ai             AI coding assistants (claude, copilot, gemini, codex, opencode, pi)
+	  ai             AI coding assistants (claude, copilot, gemini, codex, opencode, pi, omp)
 	  editors        Text editors (micro, edit, fresh, helix/hx, nvim)
 	  tuis           TUI tools (lazygit, gh-dash, yazi)
 	  multiplexers   Terminal multiplexers (tmux, zellij)

--- a/setup.sh
+++ b/setup.sh
@@ -540,13 +540,14 @@ if $INTERACTIVE; then
 				codex)    gum_selected="${gum_selected:+$gum_selected,}OpenAI Codex CLI" ;;
 				opencode) gum_selected="${gum_selected:+$gum_selected,}OpenCode" ;;
 				pi)       gum_selected="${gum_selected:+$gum_selected,}Pi Coding Agent" ;;
+				omp)      gum_selected="${gum_selected:+$gum_selected,}Oh My Pi" ;;
 			esac
 		done
 		gum_args=(--no-limit --header "Select AI coding assistants (space=toggle, enter=confirm):")
 		[ -n "$gum_selected" ] && gum_args+=(--selected "$gum_selected")
 		if ! selected=$(gum choose "${gum_args[@]}" \
 			"Claude Code" "GitHub Copilot CLI" "Google Gemini CLI" \
-			"OpenAI Codex CLI" "OpenCode" "Pi Coding Agent"); then
+			"OpenAI Codex CLI" "OpenCode" "Pi Coding Agent" "Oh My Pi"); then
 			cancel_setup
 		fi
 		ai_choice=""
@@ -558,11 +559,12 @@ if $INTERACTIVE; then
 				"OpenAI Codex CLI")   ai_choice="${ai_choice:+$ai_choice,}codex" ;;
 				"OpenCode")           ai_choice="${ai_choice:+$ai_choice,}opencode" ;;
 				"Pi Coding Agent")    ai_choice="${ai_choice:+$ai_choice,}pi" ;;
+				"Oh My Pi")           ai_choice="${ai_choice:+$ai_choice,}omp" ;;
 			esac
 		done <<< "$selected"
 	else
 		echo "Select AI coding assistants (comma-separated, 'all', or press Enter to skip):"
-		for ai_item in "1:claude:Claude Code" "2:copilot:GitHub Copilot CLI" "3:gemini:Google Gemini CLI" "4:codex:OpenAI Codex CLI" "5:opencode:OpenCode" "6:pi:Pi Coding Agent"; do
+		for ai_item in "1:claude:Claude Code" "2:copilot:GitHub Copilot CLI" "3:gemini:Google Gemini CLI" "4:codex:OpenAI Codex CLI" "5:opencode:OpenCode" "6:pi:Pi Coding Agent" "7:omp:Oh My Pi"; do
 			num="${ai_item%%:*}"; rest="${ai_item#*:}"; key="${rest%%:*}"; label="${rest#*:}"
 			if [[ ",$ai_prev," == *",${key},"* ]]; then
 				echo "  ${num}) ${label} [installed]"
@@ -570,13 +572,13 @@ if $INTERACTIVE; then
 				echo "  ${num}) ${label}"
 			fi
 		done
-		read -rp "Selection [1-6/all/skip]: " ai_selection
+		read -rp "Selection [1-7/all/skip]: " ai_selection
 		if [ -z "$ai_selection" ] && [ -n "$ai_prev" ]; then
 			ai_choice="$ai_prev"
 		else
 			ai_choice=""
 			if [ "$ai_selection" = "all" ]; then
-				ai_choice="claude,copilot,gemini,codex,opencode,pi"
+				ai_choice="claude,copilot,gemini,codex,opencode,pi,omp"
 			elif [ -n "$ai_selection" ]; then
 				for item in $(echo "$ai_selection" | tr ',' ' '); do
 					case "$item" in
@@ -586,6 +588,7 @@ if $INTERACTIVE; then
 						4) ai_choice="${ai_choice:+$ai_choice,}codex" ;;
 						5) ai_choice="${ai_choice:+$ai_choice,}opencode" ;;
 						6) ai_choice="${ai_choice:+$ai_choice,}pi" ;;
+						7) ai_choice="${ai_choice:+$ai_choice,}omp" ;;
 					esac
 				done
 			fi
@@ -602,7 +605,7 @@ fi
 supported_ai=()
 for ai_tool in $(echo "$ai_choice" | tr ',' ' '); do
 	case "$ai_tool" in
-		claude|copilot|gemini|codex|opencode|pi) supported_ai+=("$ai_tool") ;;
+		claude|copilot|gemini|codex|opencode|pi|omp) supported_ai+=("$ai_tool") ;;
 		*) echo "Warning: removing unsupported AI assistant from Selection: $ai_tool" >&2 ;;
 	esac
 done
@@ -637,6 +640,13 @@ install_pi() {
 	command -v pi >/dev/null 2>&1
 }
 
+install_omp() {
+	if command -v omp &>/dev/null && { ! $SB_RERUN || $SB_RECONCILE_BOX; }; then echo "Oh My Pi already installed, skipping."; return 0; fi
+	run_with_spinner "Installing/updating Oh My Pi (via mise)..." mise use -g github:can1357/oh-my-pi || return 1
+	_squarebox_mise_activate
+	command -v omp >/dev/null 2>&1
+}
+
 install_claude() {
 	if command -v claude >/dev/null 2>&1 && { ! $SB_RERUN || $SB_RECONCILE_BOX; }; then
 		echo "Claude Code already installed, skipping."
@@ -656,6 +666,7 @@ ai_command_present() {
 		codex) command -v codex >/dev/null 2>&1 ;;
 		opencode) command -v opencode >/dev/null 2>&1 ;;
 		pi) command -v pi >/dev/null 2>&1 ;;
+		omp) command -v omp >/dev/null 2>&1 ;;
 		*) return 1 ;;
 	esac
 }
@@ -684,6 +695,7 @@ for ai_tool in $(echo "$ai_choice" | tr ',' ' '); do
 		gemini)  install_gemini  && ai_ok=true ;;
 		codex)   install_codex   && ai_ok=true ;;
 		pi)      install_pi      && ai_ok=true ;;
+		omp)     install_omp     && ai_ok=true ;;
 	esac
 	if $ai_ok; then
 		installed_ai+=("$ai_tool")
@@ -702,7 +714,7 @@ printf '%s\n' "$ai_choice" > "$AI_CONFIG"
 # Set aliases based on selection — c maps to first selected tool in priority order
 {
 	c_target=""
-	for ai_tool in claude copilot gemini codex opencode pi; do
+	for ai_tool in claude copilot gemini codex opencode pi omp; do
 		if [[ ",$observed_ai," == *",$ai_tool,"* ]]; then
 			[ -z "$c_target" ] && c_target="$ai_tool"
 			case "$ai_tool" in

--- a/tests/test-provision-contract.sh
+++ b/tests/test-provision-contract.sh
@@ -10,6 +10,10 @@ assert() { if "$@"; then ok "$*"; else not_ok "$*"; fi; }
 
 assert grep -q 'npm install -g --silent @github/copilot' "$ROOT/setup.sh"
 assert grep -q 'ensure_node_major_for_npm 22' "$ROOT/setup.sh"
+assert grep -Fq 'mise use -g github:can1357/oh-my-pi' "$ROOT/setup.sh"
+assert grep -Fq 'command -v omp >/dev/null 2>&1' "$ROOT/setup.sh"
+assert grep -Fq 'claude|copilot|gemini|codex|opencode|pi|omp)' "$ROOT/setup.sh"
+assert grep -Fq 'ai_choice="claude,copilot,gemini,codex,opencode,pi,omp"' "$ROOT/setup.sh"
 if grep -Eq '@githubnext|github-copilot-cli' "$ROOT/setup.sh"; then
 	not_ok "deprecated Copilot package and command are absent"
 else

--- a/tests/test-provision-install-failures.sh
+++ b/tests/test-provision-install-failures.sh
@@ -185,6 +185,13 @@ assert_true "[ \"\$(cat '$OPENCODE_CASE/setup.rc')\" -ne 0 ] && [ -z \"\$(cat '$
 assert_true "grep -qx 'opencode latest' '$OPENCODE_CASE/sb-install.calls'" \
 	"OpenCode failure audit exercises its sb_install caller"
 
+OMP_CASE="$TMP/omp"
+run_selected_section ai "Oh My Pi" "$OMP_CASE"
+assert_true "[ \"\$(cat '$OMP_CASE/setup.rc')\" -ne 0 ] && [ -z \"\$(cat '$OMP_CASE/state/ai-tool')\" ]" \
+	"Oh My Pi mise failure propagates without committing a Selection"
+assert_true "grep -Fq 'mise: command not found' '$OMP_CASE/setup.out'" \
+	"Oh My Pi failure audit exercises its mise installer"
+
 # sb_install owns artifact installation, but setup owns Observed state. A
 # buggy/no-op installer returning zero must still not commit an absent command.
 NO_BINARY_CASE="$TMP/no-binary"

--- a/tests/test-provision-install-failures.sh
+++ b/tests/test-provision-install-failures.sh
@@ -58,6 +58,13 @@ cat > "$FIXTURE_BIN/gum" <<-'GUM'
 GUM
 chmod +x "$FIXTURE_BIN/gum"
 
+cat > "$FIXTURE_BIN/mise" <<-'MISE'
+	#!/bin/bash
+	printf '%s\n' "$*" >> "$MISE_CALLS"
+	exit "${MISE_RC:-42}"
+MISE
+chmod +x "$FIXTURE_BIN/mise"
+
 FIXTURE_LIB="$TMP/tool-lib.sh"
 cat > "$FIXTURE_LIB" <<-'TOOL_LIB'
 	sb_install() {
@@ -125,6 +132,7 @@ run_selected_section() {
 		ATOMIC_CAT_FAIL_PREFIX="$atomic_cat_fail_prefix" \
 		ATOMIC_FAILURE_CALLS="$case_dir/atomic-failure.calls" \
 		NETWORK_CALLS="$case_dir/network.calls" \
+		MISE_CALLS="$case_dir/mise.calls" \
 		FAKE_GUM_SELECTION="$selection" \
 		PATH="$FIXTURE_BIN" \
 		/usr/bin/script -qec "/bin/bash '$ROOT/setup.sh' --rerun '$section'" /dev/null \
@@ -189,7 +197,7 @@ OMP_CASE="$TMP/omp"
 run_selected_section ai "Oh My Pi" "$OMP_CASE"
 assert_true "[ \"\$(cat '$OMP_CASE/setup.rc')\" -ne 0 ] && [ -z \"\$(cat '$OMP_CASE/state/ai-tool')\" ]" \
 	"Oh My Pi mise failure propagates without committing a Selection"
-assert_true "grep -Fq 'mise: command not found' '$OMP_CASE/setup.out'" \
+assert_true "grep -Fqx 'use -g github:can1357/oh-my-pi' '$OMP_CASE/mise.calls'" \
 	"Oh My Pi failure audit exercises its mise installer"
 
 # sb_install owns artifact installation, but setup owns Observed state. A

--- a/uat-checklist.md
+++ b/uat-checklist.md
@@ -65,7 +65,7 @@ Tracking issues: [Linux desktop #99](https://github.com/SquareWaveSystems/square
 - [ ] Deliberately choose an empty Selection and confirm it is saved distinctly from cancel
 - [ ] Fail one assistant install and confirm aliases target the first successfully observed assistant
 - [ ] GitHub device authentication succeeds; decline marker and credentials survive Box replacement
-- [ ] Claude, Copilot, Gemini, Codex, OpenCode, and Pi launch after installation
+- [ ] Claude, Copilot, Gemini, Codex, OpenCode, Pi, and Oh My Pi launch after installation
 - [ ] Copilot uses the supported `copilot` command
 - [ ] Bash initializes Starship, Zoxide, fzf keybindings/completion, aliases, and mise shims
 - [ ] Zsh and Fish initialize Starship, Zoxide, the `fzf`/`ff` command path, aliases, and mise shims


### PR DESCRIPTION
## Summary

- add Oh My Pi as the `omp` AI assistant Selection alongside the existing Pi option
- install OMP through its official mise GitHub backend and require the `omp` command before committing observed Selection state
- update interactive setup, noninteractive keys, aliases, help, demo, README, agent guidance, and UAT coverage
- add provisioning contract and failure-propagation regression coverage

## Why

Squarebox supports several coding harnesses but did not offer the batteries-included Oh My Pi (`omp`) harness. This makes it selectable during first-run setup, reruns, scripted installs, and Dev Container provisioning without conflating it with the existing `pi` package.

## User impact

Users can select `Oh My Pi` interactively or set `SQUAREBOX_AI=omp` / `SQUAREBOX_DC_AI=omp`. Squarebox installs the current OMP release through mise, verifies that `omp` is usable, and only then persists the Selection. A failed install remains visible and does not publish stale Selection or aliases.

## Validation

- all executable `tests/test-*.sh` scripts
- `docker build --build-arg SQUAREBOX_VERSION=dev -t squarebox:test .`
- `docker run --rm -v "$PWD/scripts:/workspace/scripts:ro" squarebox:test bash -c 'scripts/e2e-test.sh smoke'` (61 passed)
- disposable real install: `mise use -g github:can1357/oh-my-pi`, followed by `omp --version` (`omp/17.1.8`); mise verified checksum, GitHub artifact attestations, and SLSA provenance
