### PR TITLE
Generalize v1.2 release controls

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -839,7 +839,7 @@ jobs:
     environment:
       # Stable publication waits for the required reviewer configured on this
       # environment. The prerelease environment is intentionally unprotected.
-      name: ${{ needs.candidate.outputs.prerelease == 'false' && 'v1.1-production' || 'v1.1-prerelease-auto' }}
+      name: ${{ needs.candidate.outputs.prerelease == 'false' && 'stable-release' || 'prerelease-auto' }}
     runs-on: ubuntu-latest
     concurrency:
       group: squarebox-release-publication

--- a/.out-of-scope/historical-v1.1-qualification.md
+++ b/.out-of-scope/historical-v1.1-qualification.md
@@ -1,0 +1,27 @@
+# Historical v1.1 qualification work
+
+Squarebox does not treat the open v1.1 qualification briefs as reusable gates
+for later Releases.
+
+## Why this is out of scope
+
+Those issues describe one version-specific Candidate and its exact source,
+image, asset, and Evidence identity. The immutable v1.1.0 Release is already
+published, so missing manual evidence cannot be retroactively attached as
+though it authorized those bytes before publication. Re-running the same
+checklists now would also not qualify the different source revision and image
+digest intended for v1.2.
+
+The historical issues are therefore closed as incomplete rather than marked as
+passed. Each new Release gets fresh qualification issues bound to its own
+Candidate identity, while the old discussions remain available as an audit
+trail.
+
+## Prior requests
+
+- #99 — Validate v1.1 Linux Docker and interactive setup
+- #100 — Validate v1.1 rootless Podman on Fedora SELinux
+- #101 — Validate v1.1 on macOS Docker Desktop
+- #102 — Validate v1.1 Windows PowerShell and Git Bash lifecycle
+- #103 — Validate v1.1 Dev Containers and Codespaces
+- #105 — Qualify the v1.1 Candidate on physical amd64 and arm64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@
   `bwrap` for its Linux sandbox instead of warning and falling back to its
   bundled helper.
 
-### Removed
-
-- Paseo assistant installation and Selection support.
-
 ## v1.1.0 — 2026-07-16
 
 ### Added
@@ -20,7 +16,7 @@
 - Bash, experimental Zsh, and experimental Fish selection.
 - tmux and Zellij selection with aligned keybindings.
 - SSH client availability in the base image.
-- Pi and Paseo assistant options.
+- Pi assistant option.
 - Version display in the MOTD and image metadata.
 - Durable Install identity for safe rebuild and uninstall behavior.
 - Assertion-backed release Evidence, SBOM/provenance, vulnerability scanning,
@@ -77,6 +73,7 @@
 
 ### Removed
 
+- Paseo assistant installation and Selection support before stable publication.
 - Disabled learn-mode commands and command-logging hook from the default image.
 
 ### Migration notes

--- a/docs/adr/0002-publish-immutable-release-identities.md
+++ b/docs/adr/0002-publish-immutable-release-identities.md
@@ -18,7 +18,7 @@ For a stable version, maintainers create the final version tag before physical
 qualification. The automated gates build that tag once, sign its Candidate
 digest and release assets, upload them to a non-discoverable draft GitHub
 Release, and verify the downloaded draft assets through the same Release
-adapter used by consumers. The workflow then stops at the `v1.1-production`
+adapter used by consumers. The workflow then stops at the `stable-release`
 environment. That environment must have a required human reviewer. Approval is
 the authorization to publish those already-prepared bytes; the publication job
 downloads and verifies them again after the wait and never rebuilds the image.
@@ -27,7 +27,7 @@ prepare a new version.
 
 Prerelease tags follow the same build, signing, draft, and verification path,
 then publish automatically through the intentionally unprotected
-`v1.1-prerelease-auto` environment. Environment protection is repository
+`prerelease-auto` environment. Environment protection is repository
 configuration, so the stable reviewer rule is a release prerequisite rather
 than something this workflow file can enforce by itself.
 

--- a/tests/test-e2e-evidence.sh
+++ b/tests/test-e2e-evidence.sh
@@ -185,7 +185,7 @@ RUBY
 # versions; prereleases use an unprotected environment and continue
 # automatically after the automated gates.
 grep -Fq 'prepare-release:' "$WORKFLOW"
-grep -Fq 'name: ${{ needs.candidate.outputs.prerelease == '\''false'\'' && '\''v1.1-production'\'' || '\''v1.1-prerelease-auto'\'' }}' "$WORKFLOW"
+grep -Fq 'name: ${{ needs.candidate.outputs.prerelease == '\''false'\'' && '\''stable-release'\'' || '\''prerelease-auto'\'' }}' "$WORKFLOW"
 
 # Execute the real embedded publication script against a fake GitHub adapter.
 # This locks the mutable-draft/immutable-rerun split and SemVer latest behavior
@@ -298,7 +298,7 @@ raise "final mutation job is not globally serialized" unless
 
 expected_environment =
   "${{ needs.candidate.outputs.prerelease == 'false' && " \
-  "'v1.1-production' || 'v1.1-prerelease-auto' }}"
+  "'stable-release' || 'prerelease-auto' }}"
 raise "stable publication is not protected by the production environment" unless
   publish.dig("environment", "name") == expected_environment
 

--- a/tests/test-provision-state.sh
+++ b/tests/test-provision-state.sh
@@ -124,7 +124,9 @@ assert_true "[ \"\$(cat '$STATE/editor-default')\" = fresh ] && grep -qx \"expor
 
 printf '#!/usr/bin/env bash\nexit 0\n' > "$BIN/codex"
 printf '#!/usr/bin/env bash\nexit 0\n' > "$BIN/npm"
-chmod +x "$BIN/codex" "$BIN/npm"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$BIN/node"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$BIN/mise"
+chmod +x "$BIN/codex" "$BIN/npm" "$BIN/node" "$BIN/mise"
 printf 'codex,removed-assistant\n' > "$STATE/ai-tool"
 if HOME="$HOME_DIR" SQUAREBOX_STATE_DIR="$STATE" \
 	SQUAREBOX_TOOL_LIB="$FIXTURE_LIB" SQUAREBOX_TOOLS_YAML=/dev/null \

--- a/uat-checklist.md
+++ b/uat-checklist.md
@@ -1,4 +1,4 @@
-# Squarebox v1.1 manual UAT
+# Squarebox v1.2 manual UAT
 
 Automated release assertions are defined in `scripts/e2e-required.tsv` and
 reported from exact Evidence by `.github/workflows/e2e.yml`. This checklist
@@ -9,18 +9,19 @@ an automated pass.
 Record the Candidate version, source SHA, image digest, host OS, architecture,
 container runtime/version, and result for every run.
 
-Tracking issues: [Linux desktop #99](https://github.com/SquareWaveSystems/squarebox/issues/99),
-[Fedora/Podman #100](https://github.com/SquareWaveSystems/squarebox/issues/100),
-[macOS #101](https://github.com/SquareWaveSystems/squarebox/issues/101),
-[Windows/Git Bash #102](https://github.com/SquareWaveSystems/squarebox/issues/102),
-[Dev Containers/Codespaces #103](https://github.com/SquareWaveSystems/squarebox/issues/103),
+Release tracker: [v1.2.0 #125](https://github.com/SquareWaveSystems/squarebox/issues/125).
+Qualification issues: [Linux desktop #126](https://github.com/SquareWaveSystems/squarebox/issues/126),
+[Fedora/Podman #127](https://github.com/SquareWaveSystems/squarebox/issues/127),
+[macOS #128](https://github.com/SquareWaveSystems/squarebox/issues/128),
+[Windows/Git Bash #129](https://github.com/SquareWaveSystems/squarebox/issues/129),
+[Dev Containers/Codespaces #130](https://github.com/SquareWaveSystems/squarebox/issues/130),
 [demo regeneration #104](https://github.com/SquareWaveSystems/squarebox/issues/104), and
-[physical Candidate qualification #105](https://github.com/SquareWaveSystems/squarebox/issues/105).
+[physical Candidate qualification #131](https://github.com/SquareWaveSystems/squarebox/issues/131).
 
 ## Linux desktop — Docker
 
 - [ ] Fresh Bash installer: launch, interactive setup, exit, resume, rebuild, uninstall
-- [ ] Existing v1.0 Managed home upgrade: no repeated prompts; selections reconcile
+- [ ] Existing v1.1 Managed home upgrade: no repeated prompts; Selections reconcile
 - [ ] Host UID/GID other than 1000: Workspace and managed files remain host-owned
 - [ ] Custom install path, Workspace, and Managed-home volume survive rebuild and purge correctly
 - [ ] Purge refuses an unrelated directory/container/image/volume with a colliding name
@@ -95,8 +96,8 @@ Tracking issues: [Linux desktop #99](https://github.com/SquareWaveSystems/square
 - [ ] Download the non-discoverable draft assets with authenticated `gh release download` and verify their hashes and Cosign identity signature
 - [ ] Run fresh and upgraded Compose flows against the digest
 - [ ] Confirm stable installers cannot discover the Release until all gates pass
-- [ ] Record the qualification evidence and explicit promote/no-promote decision in [issue #105](https://github.com/SquareWaveSystems/squarebox/issues/105)
-- [ ] Approve the waiting `v1.1-production` environment deployment to publish the tested Candidate without rebuilding different image bytes
+- [ ] Record the qualification evidence and explicit promote/no-promote decision in [issue #131](https://github.com/SquareWaveSystems/squarebox/issues/131)
+- [ ] Approve the waiting `stable-release` environment deployment to publish the tested Candidate without rebuilding different image bytes
 - [ ] After publication, run `gh release verify <tag>` and confirm GitHub reports a valid immutable-Release attestation
 - [ ] Confirm GitHub Release and GHCR `latest` identify the greatest published stable version
 - [ ] Rerun an older stable workflow (or its equivalent dry-run check) and confirm neither `latest` pointer can rewind


### PR DESCRIPTION
## Summary

- switch stable/prerelease publication from v1.1-specific GitHub environments to the preconfigured `stable-release` and `prerelease-auto` environments
- update the release ADR, automated environment assertion, and v1.2 UAT tracker
- correct the immutable v1.1 changelog record for Paseo's pre-publication removal
- record why incomplete v1.1 qualification issues cannot qualify later Candidate identities
- make the assistant-reconciliation fixture independent of host mise/Node state

## Repository controls already applied

- `stable-release` exists with BrettKinny as required reviewer
- `prerelease-auto` exists without protection rules
- active `Protect main` ruleset requires a pull request, resolved review threads, an up-to-date branch, and `repository-tests`, `build`, and `build-arm64`
- existing `Protect release tags` remains active

## Validation

- all 17 executable `tests/test-*.sh` modules pass
- Bash syntax and `git diff --check` pass

## Impact

Stable publication keeps the same human approval boundary and immutable
Candidate behavior, but the configuration no longer needs renaming for every
minor Release. The UAT checklist now points at #125–#131.
