### PR TITLE
Detach managed Zellij sessions safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
   `bwrap` for its Linux sandbox instead of warning and falling back to its
   bundled helper.
 
+### Fixed
+
+- New managed Zellij configuration detaches sessions when a client disappears;
+  exact unmodified legacy defaults migrate without overwriting user-edited or
+  symlinked configuration.
+
 ### Removed
 
 - Paseo assistant installation and Selection support.

--- a/setup.sh
+++ b/setup.sh
@@ -1408,7 +1408,7 @@ _install_zellij_inner() {
 		scroll_buffer_size 50000
 		pane_frames false
 		auto_layout true
-		on_force_close "quit"
+		on_force_close "detach"
 		simplified_ui true
 		session_serialization true
 		support_kitty_keyboard_protocol true
@@ -1640,14 +1640,48 @@ _install_zellij_inner() {
 	fi
 }
 
+_migrate_zellij_force_close_default() {
+	local conf="$HOME/.config/zellij/config.kdl"
+	local legacy_sha256="03ebc2170a89802b6452dcdb5d91dd724fe108f0c5ccfbe070edea4e5b2d6242"
+	local observed_sha256
+
+	[ -f "$conf" ] || return 0
+	# A symlink or any content change is user-managed state. Only the exact
+	# Squarebox v1.1 generated default is eligible for automatic migration.
+	[ ! -L "$conf" ] || return 0
+	command -v sha256sum >/dev/null 2>&1 || return 0
+	observed_sha256=$(sha256sum -- "$conf" 2>/dev/null | awk '{print $1}') || return 0
+	[ "$observed_sha256" = "$legacy_sha256" ] || return 0
+
+	if ! (
+		config_tmp=""
+		cleanup_zellij_migration() {
+			[ -z "$config_tmp" ] || rm -f -- "$config_tmp"
+		}
+		trap cleanup_zellij_migration EXIT
+		config_tmp=$(mktemp "$HOME/.config/zellij/.config.kdl.squarebox-migrate.XXXXXX") || exit 1
+		sed 's/^\([[:space:]]*\)on_force_close "quit"[[:space:]]*$/\1on_force_close "detach"/' \
+			"$conf" > "$config_tmp" || exit 1
+		grep -Fqx 'on_force_close "detach"' "$config_tmp" || exit 1
+		chmod --reference="$conf" "$config_tmp" || exit 1
+		mv -fT -- "$config_tmp" "$conf" || exit 1
+		config_tmp=""
+	); then
+		return 1
+	fi
+}
+
 install_zellij() {
 	if command -v zellij &>/dev/null \
 		&& [ -f "$HOME/.config/zellij/config.kdl" ] \
 		&& [ -f "$HOME/.config/zellij/layouts/default.kdl" ]; then
-		echo "Zellij already installed, skipping."
+		_migrate_zellij_force_close_default || return 1
+		echo "Zellij already installed, configuration reconciled."
 		return 0
 	fi
-	run_with_spinner "Installing Zellij..." _install_zellij_inner
+	run_with_spinner "Installing Zellij..." _install_zellij_inner || return 1
+	_migrate_zellij_force_close_default || return 1
+	command -v zellij >/dev/null 2>&1
 }
 
 installed_mux=()

--- a/tests/test-provision-install-failures.sh
+++ b/tests/test-provision-install-failures.sh
@@ -16,7 +16,7 @@ assert_true() { if eval "$1"; then ok "$2"; else not_ok "$2"; fi; }
 # observed success.
 FIXTURE_BIN="$TMP/bin"
 mkdir -p "$FIXTURE_BIN"
-for utility in bash jq mkdir mktemp rm touch tr; do
+for utility in awk bash chmod grep jq mkdir mktemp rm sed sha256sum touch tr; do
 	ln -s "$(command -v "$utility")" "$FIXTURE_BIN/$utility"
 done
 
@@ -234,6 +234,16 @@ assert_true "[ ! -e '$ZELLIJ_LAYOUT_WRITE_FAILURE_CASE/home/.config/zellij/layou
 run_selected_section multiplexers zellij "$ZELLIJ_LAYOUT_WRITE_FAILURE_CASE" 0
 assert_true "[ \"\$(cat '$ZELLIJ_LAYOUT_WRITE_FAILURE_CASE/setup.rc')\" -eq 0 ] && grep -Fq 'shared_except \"normal\" \"locked\" \"tmux\"' '$ZELLIJ_LAYOUT_WRITE_FAILURE_CASE/home/.config/zellij/config.kdl' && grep -Fq 'plugin location=\"compact-bar\"' '$ZELLIJ_LAYOUT_WRITE_FAILURE_CASE/home/.config/zellij/layouts/default.kdl'" \
 	"Zellij rerun reconciles a missing layout beside an already-published config"
+
+ZELLIJ_MIGRATION_FAILURE_CASE="$TMP/zellij-migration-failure"
+run_selected_section multiplexers zellij "$ZELLIJ_MIGRATION_FAILURE_CASE" 0
+sed -i 's/on_force_close "detach"/on_force_close "quit"/' \
+	"$ZELLIJ_MIGRATION_FAILURE_CASE/home/.config/zellij/config.kdl"
+run_selected_section multiplexers zellij "$ZELLIJ_MIGRATION_FAILURE_CASE" 0 fail expected clean config.kdl
+assert_true "[ \"\$(cat '$ZELLIJ_MIGRATION_FAILURE_CASE/setup.rc')\" -ne 0 ] && grep -Fqx 'on_force_close \"quit\"' '$ZELLIJ_MIGRATION_FAILURE_CASE/home/.config/zellij/config.kdl'" \
+	"Zellij migration publish failure remains visible and preserves the legacy config"
+assert_true "! find '$ZELLIJ_MIGRATION_FAILURE_CASE/home/.config/zellij' -maxdepth 1 -name '.config.kdl.squarebox-migrate.*' | grep -q ." \
+	"failed Zellij migration removes its destination-local staging file"
 
 # Adjacent apt-backed installers can suffer the same conditional-function
 # masking. Make tmux observable while forcing its config directory creation to

--- a/tests/test-provision-state.sh
+++ b/tests/test-provision-state.sh
@@ -155,7 +155,17 @@ ZELLIJ_CONF="$HOME_DIR/.config/zellij/config.kdl"
 assert_true "grep -Fqx 'on_force_close \"detach\"' '$ZELLIJ_CONF' && ! grep -Fq 'on_force_close \"quit\"' '$ZELLIJ_CONF'" \
 	"fresh managed Zellij config detaches on client loss"
 
-sed -i 's/on_force_close "detach"/on_force_close "quit"/' "$ZELLIJ_CONF"
+sed -i \
+	-e 's#// Prefix-style bindings\. Ctrl+B is available for clients that#// Prefix-style bindings via Ctrl+Space (tmux-like leader)#' \
+	-e '/\/\/ cannot deliver Ctrl+Space (for example, some mobile stacks)./d' \
+	-e '/bind "Ctrl b" { SwitchToMode "Tmux"; }/d' \
+	-e '/bind "Ctrl b" { SwitchToMode "Normal"; }/d' \
+	-e '/\/\/ Discoverable help for this clear-defaults configuration\./,/^[[:space:]]*}[[:space:]]*$/d' \
+	-e '/\/\/ Scroll\/search reserve Ctrl+B for page-up\./,/^[[:space:]]*}[[:space:]]*$/d' \
+	-e 's/on_force_close "detach"/on_force_close "quit"/' \
+	"$ZELLIJ_CONF"
+assert_true "[ \"\$(sha256sum '$ZELLIJ_CONF' | awk '{print \$1}')\" = 03ebc2170a89802b6452dcdb5d91dd724fe108f0c5ccfbe070edea4e5b2d6242 ]" \
+	"legacy Zellij migration fixture matches the recorded v1.1 managed default"
 HOME="$HOME_DIR" SQUAREBOX_STATE_DIR="$STATE" \
 	SQUAREBOX_TOOL_LIB="$FIXTURE_LIB" SQUAREBOX_TOOLS_YAML=/dev/null \
 	PATH="$BIN:$PATH" bash "$ROOT/setup.sh" --rerun multiplexers >"$TMP/zellij-legacy.out" 2>"$TMP/zellij-legacy.err"

--- a/tests/test-provision-state.sh
+++ b/tests/test-provision-state.sh
@@ -124,7 +124,9 @@ assert_true "[ \"\$(cat '$STATE/editor-default')\" = fresh ] && grep -qx \"expor
 
 printf '#!/usr/bin/env bash\nexit 0\n' > "$BIN/codex"
 printf '#!/usr/bin/env bash\nexit 0\n' > "$BIN/npm"
-chmod +x "$BIN/codex" "$BIN/npm"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$BIN/node"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$BIN/mise"
+chmod +x "$BIN/codex" "$BIN/npm" "$BIN/node" "$BIN/mise"
 printf 'codex,removed-assistant\n' > "$STATE/ai-tool"
 if HOME="$HOME_DIR" SQUAREBOX_STATE_DIR="$STATE" \
 	SQUAREBOX_TOOL_LIB="$FIXTURE_LIB" SQUAREBOX_TOOLS_YAML=/dev/null \
@@ -139,6 +141,52 @@ HOME="$HOME_DIR" SQUAREBOX_STATE_DIR="$STATE" \
 	SQUAREBOX_TOOL_LIB="$FIXTURE_LIB" SQUAREBOX_TOOLS_YAML=/dev/null \
 	PATH="$BIN:$PATH" bash "$ROOT/setup.sh" --reconcile-box >"$TMP/reconcile-off.out" 2>"$TMP/reconcile-off.err"
 assert_true "! grep -q 'mouse on' '$HOME_DIR/.config/tmux/tmux.conf'" "tmux migration never overrides explicit mouse-off"
+
+# Fresh Zellij config detaches sessions. Only the byte-exact legacy managed
+# default is migrated; any edit or symlink remains user-controlled.
+printf '#!/usr/bin/env bash\nexit 0\n' > "$BIN/zellij"
+chmod +x "$BIN/zellij"
+printf 'zellij\n' > "$STATE/multiplexer"
+rm -rf "$HOME_DIR/.config/zellij"
+HOME="$HOME_DIR" SQUAREBOX_STATE_DIR="$STATE" \
+	SQUAREBOX_TOOL_LIB="$FIXTURE_LIB" SQUAREBOX_TOOLS_YAML=/dev/null \
+	PATH="$BIN:$PATH" bash "$ROOT/setup.sh" --rerun multiplexers >"$TMP/zellij-fresh.out" 2>"$TMP/zellij-fresh.err"
+ZELLIJ_CONF="$HOME_DIR/.config/zellij/config.kdl"
+assert_true "grep -Fqx 'on_force_close \"detach\"' '$ZELLIJ_CONF' && ! grep -Fq 'on_force_close \"quit\"' '$ZELLIJ_CONF'" \
+	"fresh managed Zellij config detaches on client loss"
+
+sed -i 's/on_force_close "detach"/on_force_close "quit"/' "$ZELLIJ_CONF"
+HOME="$HOME_DIR" SQUAREBOX_STATE_DIR="$STATE" \
+	SQUAREBOX_TOOL_LIB="$FIXTURE_LIB" SQUAREBOX_TOOLS_YAML=/dev/null \
+	PATH="$BIN:$PATH" bash "$ROOT/setup.sh" --rerun multiplexers >"$TMP/zellij-legacy.out" 2>"$TMP/zellij-legacy.err"
+assert_true "grep -Fqx 'on_force_close \"detach\"' '$ZELLIJ_CONF'" \
+	"exact legacy managed Zellij config migrates to detach"
+
+sed -i 's/on_force_close "detach"/on_force_close "quit"/' "$ZELLIJ_CONF"
+printf '// explicit user edit\n' >> "$ZELLIJ_CONF"
+HOME="$HOME_DIR" SQUAREBOX_STATE_DIR="$STATE" \
+	SQUAREBOX_TOOL_LIB="$FIXTURE_LIB" SQUAREBOX_TOOLS_YAML=/dev/null \
+	PATH="$BIN:$PATH" bash "$ROOT/setup.sh" --rerun multiplexers >"$TMP/zellij-edited.out" 2>"$TMP/zellij-edited.err"
+assert_true "grep -Fqx 'on_force_close \"quit\"' '$ZELLIJ_CONF' && grep -Fqx '// explicit user edit' '$ZELLIJ_CONF'" \
+	"Zellij migration preserves an edited managed config"
+
+printf 'on_force_close "quit"\n' > "$ZELLIJ_CONF"
+HOME="$HOME_DIR" SQUAREBOX_STATE_DIR="$STATE" \
+	SQUAREBOX_TOOL_LIB="$FIXTURE_LIB" SQUAREBOX_TOOLS_YAML=/dev/null \
+	PATH="$BIN:$PATH" bash "$ROOT/setup.sh" --rerun multiplexers >"$TMP/zellij-user.out" 2>"$TMP/zellij-user.err"
+assert_true "grep -Fqx 'on_force_close \"quit\"' '$ZELLIJ_CONF'" \
+	"Zellij migration preserves a user-authored force-close choice"
+
+ZELLIJ_OUTSIDE="$TMP/zellij-outside.kdl"
+printf 'on_force_close "quit"\n' > "$ZELLIJ_OUTSIDE"
+rm -f "$ZELLIJ_CONF"
+ln -s "$ZELLIJ_OUTSIDE" "$ZELLIJ_CONF"
+HOME="$HOME_DIR" SQUAREBOX_STATE_DIR="$STATE" \
+	SQUAREBOX_TOOL_LIB="$FIXTURE_LIB" SQUAREBOX_TOOLS_YAML=/dev/null \
+	PATH="$BIN:$PATH" bash "$ROOT/setup.sh" --rerun multiplexers >"$TMP/zellij-symlink.out" 2>"$TMP/zellij-symlink.err"
+assert_true "[ -L '$ZELLIJ_CONF' ] && grep -Fqx 'on_force_close \"quit\"' '$ZELLIJ_OUTSIDE'" \
+	"Zellij migration does not rewrite a symlinked config"
+rm -f "$ZELLIJ_CONF"
 
 # A gum cancellation and a confirmed empty multi-select are different state
 # transitions: cancel preserves prior files; empty intentionally clears them.


### PR DESCRIPTION
## Summary

- generate `on_force_close "detach"` for new managed Zellij configuration
- migrate only the byte-exact Squarebox v1.1 legacy default
- leave user-authored, edited, and symlinked configuration untouched
- publish migration through a destination-local atomic stage and preserve the legacy file on failure
- reconcile the migration even when Zellij and both managed config files already exist

## Root cause

The previous managed default used `quit`, so a lost SSH/mosh/mobile client
terminated the session and its processes. PR #118 attempted a broad `sed -i`
migration that could overwrite an explicit user choice.

This replacement fingerprints the complete generated legacy template. Any
content change transfers control to the user and makes automatic migration a
no-op.

## Validation

- all 17 executable `tests/test-*.sh` modules pass
- 21 state/reconciliation assertions cover fresh, exact-legacy, edited,
  user-authored, and symlinked configurations
- 56 install/failure assertions include injected migration publication failure
  and staging cleanup
- Bash syntax and `git diff --check` pass

Closes #132.
