### PR TITLE
Add alternate Zellij leader and help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - `bubblewrap` in the base image so the OpenAI Codex CLI uses the system
   `bwrap` for its Linux sandbox instead of warning and falling back to its
   bundled helper.
+- Fresh managed Zellij configuration offers Ctrl+B as an alternate leader and
+  a prefix-mode help popup without shadowing scroll/search page-up.
 
 ### Fixed
 

--- a/setup.sh
+++ b/setup.sh
@@ -1488,16 +1488,20 @@ _install_zellij_inner() {
 		            };
 		        }
 
-		        // Prefix-style bindings via Ctrl+Space (tmux-like leader)
+		        // Prefix-style bindings. Ctrl+B is available for clients that
+		        // cannot deliver Ctrl+Space (for example, some mobile stacks).
 		        bind "Ctrl Space" { SwitchToMode "Tmux"; }
+		        bind "Ctrl b" { SwitchToMode "Tmux"; }
 		    }
 
 		    locked {
 		        bind "Ctrl Space" { SwitchToMode "Normal"; }
+		        bind "Ctrl b" { SwitchToMode "Normal"; }
 		    }
 
 		    tmux {
 		        bind "Ctrl Space" { SwitchToMode "Normal"; }
+		        bind "Ctrl b" { SwitchToMode "Normal"; }
 		        bind "Esc" { SwitchToMode "Normal"; }
 
 		        // Pane splitting (h=horizontal, v=vertical — matching tmux)
@@ -1546,6 +1550,11 @@ _install_zellij_inner() {
 
 		        // Enter scroll/copy mode (vi-style — like tmux [ )
 		        bind "[" { SwitchToMode "Scroll"; }
+		        // Discoverable help for this clear-defaults configuration.
+		        bind "?" {
+		            LaunchOrFocusPlugin "configuration" { floating true; };
+		            SwitchToMode "Normal";
+		        }
 		    }
 
 		    // ── Scroll mode (vi-style copy mode) ────────────────────────
@@ -1602,6 +1611,10 @@ _install_zellij_inner() {
 		    // Allow Ctrl+Space to return to normal from any non-normal mode
 		    shared_except "normal" "locked" "tmux" {
 		        bind "Ctrl Space" { SwitchToMode "Normal"; }
+		    }
+		    // Scroll/search reserve Ctrl+B for page-up.
+		    shared_except "normal" "locked" "tmux" "scroll" "search" {
+		        bind "Ctrl b" { SwitchToMode "Normal"; }
 		    }
 		}
 			ZELLIJCONF

--- a/tests/test-provision-install-failures.sh
+++ b/tests/test-provision-install-failures.sh
@@ -237,7 +237,14 @@ assert_true "[ \"\$(cat '$ZELLIJ_LAYOUT_WRITE_FAILURE_CASE/setup.rc')\" -eq 0 ] 
 
 ZELLIJ_MIGRATION_FAILURE_CASE="$TMP/zellij-migration-failure"
 run_selected_section multiplexers zellij "$ZELLIJ_MIGRATION_FAILURE_CASE" 0
-sed -i 's/on_force_close "detach"/on_force_close "quit"/' \
+sed -i \
+	-e 's#// Prefix-style bindings\. Ctrl+B is available for clients that#// Prefix-style bindings via Ctrl+Space (tmux-like leader)#' \
+	-e '/\/\/ cannot deliver Ctrl+Space (for example, some mobile stacks)./d' \
+	-e '/bind "Ctrl b" { SwitchToMode "Tmux"; }/d' \
+	-e '/bind "Ctrl b" { SwitchToMode "Normal"; }/d' \
+	-e '/\/\/ Discoverable help for this clear-defaults configuration\./,/^[[:space:]]*}[[:space:]]*$/d' \
+	-e '/\/\/ Scroll\/search reserve Ctrl+B for page-up\./,/^[[:space:]]*}[[:space:]]*$/d' \
+	-e 's/on_force_close "detach"/on_force_close "quit"/' \
 	"$ZELLIJ_MIGRATION_FAILURE_CASE/home/.config/zellij/config.kdl"
 run_selected_section multiplexers zellij "$ZELLIJ_MIGRATION_FAILURE_CASE" 0 fail expected clean config.kdl
 assert_true "[ \"\$(cat '$ZELLIJ_MIGRATION_FAILURE_CASE/setup.rc')\" -ne 0 ] && grep -Fqx 'on_force_close \"quit\"' '$ZELLIJ_MIGRATION_FAILURE_CASE/home/.config/zellij/config.kdl'" \

--- a/tests/test-provision-state.sh
+++ b/tests/test-provision-state.sh
@@ -154,8 +154,24 @@ HOME="$HOME_DIR" SQUAREBOX_STATE_DIR="$STATE" \
 ZELLIJ_CONF="$HOME_DIR/.config/zellij/config.kdl"
 assert_true "grep -Fqx 'on_force_close \"detach\"' '$ZELLIJ_CONF' && ! grep -Fq 'on_force_close \"quit\"' '$ZELLIJ_CONF'" \
 	"fresh managed Zellij config detaches on client loss"
+assert_true "[ \"\$(grep -Fc 'bind \"Ctrl b\" { SwitchToMode \"Tmux\"; }' '$ZELLIJ_CONF')\" -eq 1 ] && [ \"\$(grep -Fc 'bind \"Ctrl b\" { SwitchToMode \"Normal\"; }' '$ZELLIJ_CONF')\" -eq 3 ]" \
+	"fresh managed Zellij config provides Ctrl+B leader entry and exits"
+assert_true "grep -Fq 'LaunchOrFocusPlugin \"configuration\" { floating true; };' '$ZELLIJ_CONF' && grep -Fq 'shared_except \"normal\" \"locked\" \"tmux\" \"scroll\" \"search\"' '$ZELLIJ_CONF'" \
+	"fresh managed Zellij config exposes help without shadowing scroll/search Ctrl+B"
+assert_true "[ \"\$(grep -Fc 'bind \"Ctrl b\" \"PageUp\" { PageScrollUp; }' '$ZELLIJ_CONF')\" -eq 2 ]" \
+	"scroll and search retain Ctrl+B page-up"
 
-sed -i 's/on_force_close "detach"/on_force_close "quit"/' "$ZELLIJ_CONF"
+sed -i \
+	-e 's#// Prefix-style bindings\. Ctrl+B is available for clients that#// Prefix-style bindings via Ctrl+Space (tmux-like leader)#' \
+	-e '/\/\/ cannot deliver Ctrl+Space (for example, some mobile stacks)./d' \
+	-e '/bind "Ctrl b" { SwitchToMode "Tmux"; }/d' \
+	-e '/bind "Ctrl b" { SwitchToMode "Normal"; }/d' \
+	-e '/\/\/ Discoverable help for this clear-defaults configuration\./,/^[[:space:]]*}[[:space:]]*$/d' \
+	-e '/\/\/ Scroll\/search reserve Ctrl+B for page-up\./,/^[[:space:]]*}[[:space:]]*$/d' \
+	-e 's/on_force_close "detach"/on_force_close "quit"/' \
+	"$ZELLIJ_CONF"
+assert_true "[ \"\$(sha256sum '$ZELLIJ_CONF' | awk '{print \$1}')\" = 03ebc2170a89802b6452dcdb5d91dd724fe108f0c5ccfbe070edea4e5b2d6242 ]" \
+	"legacy Zellij migration fixture matches the recorded v1.1 managed default"
 HOME="$HOME_DIR" SQUAREBOX_STATE_DIR="$STATE" \
 	SQUAREBOX_TOOL_LIB="$FIXTURE_LIB" SQUAREBOX_TOOLS_YAML=/dev/null \
 	PATH="$BIN:$PATH" bash "$ROOT/setup.sh" --rerun multiplexers >"$TMP/zellij-legacy.out" 2>"$TMP/zellij-legacy.err"


### PR DESCRIPTION
## Summary

- add Ctrl+B as an alternate leader for fresh managed Zellij configuration
- expose the built-in configuration plugin as prefix-mode `?` help
- keep Ctrl+B page-up mode-specific in scroll and search
- leave every existing Zellij config untouched; this optional feature has no automatic keybinding migration

## Stacked review

This PR is intentionally based on #136 so its diff contains only the optional
keybinding/help feature. After #136 merges, retarget this PR to `main`.

## Validation

- 25 state/reconciliation assertions pass, including leader counts, help
  discovery, scroll/search precedence, exact legacy detach migration, edited
  config, and symlink preservation
- the generated KDL passes `zellij setup --check` using the digest-verified
  official Zellij v0.44.3 Linux x86_64 release asset
- Bash syntax and `git diff --check` pass

Closes #133.
