### PR TITLE
Persist Dev Container managed home across rebuilds

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,13 @@
   },
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
   "workspaceFolder": "/workspace",
+  "mounts": [
+    {
+      "source": "squarebox-home-${devcontainerId}",
+      "target": "/home/dev",
+      "type": "volume"
+    }
+  ],
   "remoteUser": "dev",
   "containerEnv": {
     "DEVCONTAINER": "1"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -293,7 +293,7 @@ jobs:
         run: |
           scripts/e2e-test.sh devcontainer
           scripts/e2e-evidence.sh pass devcontainer.state \
-            "Dev Container configuration aligns Workspace and selection state under /workspace"
+            "Dev Container configuration aligns Workspace state under /workspace and declares an isolated rebuild-stable Managed-home volume"
 
       - name: Real stop/start and replacement reconciliation
         env:

--- a/README.md
+++ b/README.md
@@ -525,7 +525,10 @@ Open this repo in VS Code with the
 or launch it in [GitHub Codespaces](https://github.com/features/codespaces).
 The included `.devcontainer/devcontainer.json` builds the full **squarebox** image
 automatically and mounts the cloned repository at `/workspace`, matching setup
-and Selection state.
+and Selection state. A per-Box named volume, derived from the stable
+Dev Container identity, mounts at `/home/dev` so authentication, history, and
+mise toolchains survive container rebuilds without being shared across
+unrelated workspaces.
 
 The interactive first-run wizard can't run in devcontainer mode (no TTY at
 create time), so a default toolset — **Claude Code + Node.js** — is installed

--- a/scripts/e2e-required.tsv
+++ b/scripts/e2e-required.tsv
@@ -20,6 +20,6 @@ update.single	A named tool update follows named-tool semantics
 update.failure	Updater failures produce a nonzero aggregate result
 dotfiles.refresh	A stale Managed-home dotfile is safely refreshed
 dotfiles.symlink	Managed dotfile refresh rejects symlink destinations
-devcontainer.state	Dev Container configuration aligns Workspace and selection state under /workspace
+devcontainer.state	Dev Container configuration aligns Workspace state under /workspace and declares an isolated rebuild-stable Managed-home volume
 setup.rerun	The setup wrapper validates input and a noninteractive Git-section rerun succeeds
 learn.not-shipped	Disabled learn commands and hooks are absent from the default image

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -376,6 +376,12 @@ suite_devcontainer() {
 		jq -r '.workspaceFolder' "$dc"
 	run_test_grep "8.3b workspaceMount targets /workspace" "target=/workspace" \
 		jq -r '.workspaceMount' "$dc"
+	run_test "8.3c Managed home uses one rebuild-stable per-Box volume" \
+		jq -e '[.mounts[]? | select(
+			.source == "squarebox-home-${devcontainerId}" and
+			.target == "/home/dev" and
+			.type == "volume"
+		)] | length == 1' "$dc"
 
 	# 8.4 user is dev
 	run_test_grep "8.4 remoteUser is dev" "dev" jq -r '.remoteUser' "$dc"

--- a/tests/test-lifecycle-static.sh
+++ b/tests/test-lifecycle-static.sh
@@ -10,6 +10,11 @@ python3 -m json.tool .devcontainer/devcontainer.json >/dev/null
 
 grep -q 'workspaceMount.*target=/workspace' .devcontainer/devcontainer.json
 grep -q '"workspaceFolder": "/workspace"' .devcontainer/devcontainer.json
+test "$(jq '[.mounts[]? | select(
+  .source == "squarebox-home-${devcontainerId}" and
+  .target == "/home/dev" and
+  .type == "volume"
+)] | length' .devcontainer/devcontainer.json)" = 1
 grep -q 'name: ${SQUAREBOX_HOME_VOLUME:-squarebox-home}' docker-compose.yml
 grep -q 'image: ${SQUAREBOX_IMAGE_REF:-ghcr.io/squarewavesystems/squarebox:latest}' docker-compose.yml
 grep -q 'io.squarebox.managed: "true"' docker-compose.yml

--- a/tests/test-repository-consistency.sh
+++ b/tests/test-repository-consistency.sh
@@ -28,6 +28,12 @@ test "$(jq -r .workspaceFolder .devcontainer/devcontainer.json)" = /workspace \
 	|| fail "Dev Container Workspace differs from setup state"
 jq -r .workspaceMount .devcontainer/devcontainer.json | grep -Fq 'target=/workspace' \
 	|| fail "Dev Container mount does not target /workspace"
+test "$(jq '[.mounts[]? | select(
+	.source == "squarebox-home-${devcontainerId}" and
+	.target == "/home/dev" and
+	.type == "volume"
+)] | length' .devcontainer/devcontainer.json)" = 1 \
+	|| fail "Dev Container Managed home is not a rebuild-stable, per-Box volume"
 
 if grep -E '(USER_HOME|\$HOME|USERPROFILE).*[.]config/git' \
 	install.sh install.ps1 docker-compose.yml >/dev/null; then


### PR DESCRIPTION
## Summary

- mount `/home/dev` from a named volume keyed by the stable `${devcontainerId}`
- keep credentials, history, and mise toolchains isolated per Box and persistent across rebuilds
- add repository assertions and document the persistence contract

## Release context

This fixes the release-blocking persistence failure reproduced during #130 qualification. The protected `v1.2.0` tag cannot be retargeted, so this must land through the normal main PR path before a new final Candidate version is created.

## Validation

- reproduced the failure on tagged v1.2.0 with Dev Container CLI 0.87.0
- verified the fix through repeated `devcontainer up --remove-existing-container` rebuilds; Workspace and Managed-home markers both survived with `dev` ownership
- all executable repository test modules pass
- `git diff --check` passes

Refs #130