### PR TITLE
Fix Codespaces SSH access with a locked feature

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/sshd:1.1.0": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/sshd@sha256:f5251b8e4325f68f7280973c6cd65daff414449c66f240621502d4e8e74eb7ee",
+      "integrity": "sha256:f5251b8e4325f68f7280973c6cd65daff414449c66f240621502d4e8e74eb7ee"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,11 @@
     "context": "..",
     "dockerfile": "../Dockerfile"
   },
+  "features": {
+    "ghcr.io/devcontainers/features/sshd:1.1.0": {
+      "gatewayPorts": "no"
+    }
+  },
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
   "workspaceFolder": "/workspace",
   "mounts": [

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,8 +101,10 @@ jobs:
             du -sh /* 2>/dev/null | sort -rh | head -20
           '
 
-      - name: Devcontainer config is valid JSON
-        run: jq empty .devcontainer/devcontainer.json
+      - name: Devcontainer config and lock are valid JSON
+        run: |
+          jq empty .devcontainer/devcontainer.json
+          jq empty .devcontainer/devcontainer-lock.json
 
       - name: Container creates successfully
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ stable v1.2 release and includes that fix.
   replacement.
 - Dev Container and Codespaces post-create defaults now support terminal
   multiplexers alongside assistants, SDKs, editors, and TUIs.
+- Codespaces created from the custom Squarebox image include a digest-locked
+  SSH server Feature, so `gh codespace ssh` can attach as documented.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -547,7 +547,10 @@ To add or change tools after the fact, run `sqrbx-setup` from the integrated
 terminal.
 
 You can also attach to a running codespace directly from your local terminal
-using `gh codespace ssh`.
+using `gh codespace ssh`. The official Dev Containers SSH server Feature is
+version- and digest-locked for this path. It is added only to the derived Dev
+Container image, not the published Squarebox Candidate, and remote-forwarded
+ports remain bound to loopback by default.
 
 Uninstall
 ---------

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -218,6 +218,12 @@ The `dev` user can invoke passwordless package-management/install commands.
 inside the Box, so the sudo allowlist is an operational control, not a security
 barrier against a malicious Box user.
 
+Dev Container and Codespaces builds add the digest-locked official SSH server
+Feature to the derived development image; the published Squarebox Candidate
+does not contain that server. The upstream Feature enables root login in its
+SSHD configuration, but Squarebox publishes no SSH host port or password, and
+restricts remote-forwarded listeners to loopback.
+
 Linux capabilities are reduced, but the Box has network access and the host
 resources explicitly mounted by its Install identity. Treat code and tools run
 inside it as having access to:

--- a/docs/releases/v1.2.1.md
+++ b/docs/releases/v1.2.1.md
@@ -49,7 +49,8 @@ same Release.
   prefix-mode help popup, and safe detach behavior when a client disappears.
 - Dev Containers retain authentication, history, and mise toolchains in an
   isolated Managed-home volume across rebuilds, and their noninteractive
-  defaults can select terminal multiplexers.
+  defaults can select terminal multiplexers. Codespaces also include a pinned
+  SSH server Feature so `gh codespace ssh` works with the custom image.
 - xh, just, and mise advance with reviewed amd64 and arm64 checksums.
 
 The new optional tools are not forced into an existing Selection. Run

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -361,6 +361,9 @@ suite_update() {
 suite_devcontainer() {
 	# These tests validate the devcontainer.json config file
 	local dc=".devcontainer/devcontainer.json"
+	local dc_lock=".devcontainer/devcontainer-lock.json"
+	local sshd_feature="ghcr.io/devcontainers/features/sshd:1.1.0"
+	local sshd_digest="sha256:f5251b8e4325f68f7280973c6cd65daff414449c66f240621502d4e8e74eb7ee"
 
 	if [ ! -f "$dc" ]; then
 		tap_fail "8.1 devcontainer.json exists" "file not found: $dc"
@@ -394,6 +397,19 @@ suite_devcontainer() {
 
 	# 8.7 post-create script exists and is syntactically valid bash
 	run_test "8.7 devcontainer-postcreate.sh parses" bash -n scripts/devcontainer-postcreate.sh
+
+	# 8.8 Codespaces CLI access uses the reviewed, locked SSH server Feature
+	# without permitting remote-forwarded ports to listen beyond localhost.
+	run_test_grep "8.8 SSH server Feature restricts gateway ports to loopback" "^no$" \
+		jq -r --arg id "$sshd_feature" '.features[$id].gatewayPorts // empty' "$dc"
+	run_test "8.9 Dev Container Feature lock exists" test -f "$dc_lock"
+	run_test_grep "8.9b SSH server Feature version is locked" "^1[.]1[.]0$" \
+		jq -r --arg id "$sshd_feature" '.features[$id].version // empty' "$dc_lock"
+	run_test_grep "8.9c SSH server Feature resolution is digest-pinned" \
+		"^ghcr[.]io/devcontainers/features/sshd@$sshd_digest$" \
+		jq -r --arg id "$sshd_feature" '.features[$id].resolved // empty' "$dc_lock"
+	run_test_grep "8.9d SSH server Feature integrity is reviewed" "^$sshd_digest$" \
+		jq -r --arg id "$sshd_feature" '.features[$id].integrity // empty' "$dc_lock"
 }
 
 # ── Suite: setup-rerun ───────────────────────────────────────────────────

--- a/tests/test-repository-consistency.sh
+++ b/tests/test-repository-consistency.sh
@@ -28,6 +28,26 @@ test "$(jq -r .workspaceFolder .devcontainer/devcontainer.json)" = /workspace \
 	|| fail "Dev Container Workspace differs from setup state"
 jq -r .workspaceMount .devcontainer/devcontainer.json | grep -Fq 'target=/workspace' \
 	|| fail "Dev Container mount does not target /workspace"
+
+SSHD_FEATURE=ghcr.io/devcontainers/features/sshd:1.1.0
+SSHD_DIGEST=sha256:f5251b8e4325f68f7280973c6cd65daff414449c66f240621502d4e8e74eb7ee
+DEVCONTAINER_LOCK=.devcontainer/devcontainer-lock.json
+
+test "$(jq -r --arg id "$SSHD_FEATURE" \
+	'.features[$id].gatewayPorts // empty' \
+	.devcontainer/devcontainer.json)" = no \
+	|| fail "Dev Container SSH server feature is absent or permits non-loopback gateway forwarding"
+test "$(jq -r --arg id "$SSHD_FEATURE" \
+	'.features[$id].version // empty' "$DEVCONTAINER_LOCK")" = 1.1.0 \
+	|| fail "Dev Container SSH server feature version is not locked"
+test "$(jq -r --arg id "$SSHD_FEATURE" \
+	'.features[$id].resolved // empty' "$DEVCONTAINER_LOCK")" \
+	= "ghcr.io/devcontainers/features/sshd@$SSHD_DIGEST" \
+	|| fail "Dev Container SSH server feature resolution is not digest-pinned"
+test "$(jq -r --arg id "$SSHD_FEATURE" \
+	'.features[$id].integrity // empty' "$DEVCONTAINER_LOCK")" \
+	= "$SSHD_DIGEST" \
+	|| fail "Dev Container SSH server feature integrity does not match the reviewed digest"
 test "$(jq '[.mounts[]? | select(
 	.source == "squarebox-home-${devcontainerId}" and
 	.target == "/home/dev" and

--- a/uat-checklist.md
+++ b/uat-checklist.md
@@ -85,6 +85,7 @@ Qualification issues: [Linux desktop #126](https://github.com/SquareWaveSystems/
 ## Dev Containers and Codespaces
 
 - [ ] VS Code Dev Containers builds the tagged Candidate source, runs `postCreateCommand`, and reopens successfully (source rebuild is not byte-identical to the published image)
+- [ ] `gh codespace ssh` attaches to a Codespace built from the custom Squarebox image
 - [ ] GitHub Codespaces runs the noninteractive defaults and preserves independent successful Selections after one section fails
 - [ ] Custom `SQUAREBOX_DC_MULTIPLEXERS` defaults are observed; an explicit empty value opts out; and an existing multiplexer Selection takes precedence on rebuild
 - [ ] Rebuilds preserve Workspace Selection state and Managed-home authentication/toolchains


### PR DESCRIPTION
## Summary

- add the official Dev Containers SSHD Feature only to the derived Dev Container/Codespaces image
- pin Feature 1.1.0 to reviewed OCI digest `sha256:f5251b8e4325f68f7280973c6cd65daff414449c66f240621502d4e8e74eb7ee`
- restrict remote-forwarded listeners to loopback and document the upstream SSH security behavior
- add repository, Candidate E2E, CI JSON, release-note, and UAT coverage

## Diagnosis

Real `v1.2.1-rc1` Codespaces qualification reached `Available`, but `gh codespace ssh` and logs failed because the custom Squarebox image had no SSH server. The exact rc1 digest reproduced the missing `sshd` binary. GitHub recommends the official SSHD Feature for custom Debian-based Codespaces images.

## Validation

- regression assertions failed before the fix and now pass
- all 17 executable repository test modules pass
- Dev Containers CLI 0.87.0 `build --frozen-lockfile` passes
- real derived-container `up --frozen-lockfile` passes
- `/usr/sbin/sshd -t` passes, daemon PID is live, and `GatewayPorts no` is effective
- disposable local container and Managed-home volume removed

`v1.2.1-rc1` remains immutable failed Codespaces qualification evidence. After merge, this requires rc2 and a fresh real Codespaces rerun before any final stable tag.