### PR TITLE
Fix UID remap with read-only home binds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,6 +146,9 @@ jobs:
           docker exec sqrbx-persist grep -q "persist-ok" /home/dev/testfile
           echo "Persistence test passed"
 
+      - name: Non-default identity handles read-only Managed-home binds
+        run: scripts/test-nondefault-id.sh squarebox:test
+
       - name: In-image smoke assertions
         run: |
           docker run --rm \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -295,6 +295,14 @@ jobs:
           scripts/e2e-evidence.sh pass devcontainer.state \
             "Dev Container configuration aligns Workspace state under /workspace and declares an isolated rebuild-stable Managed-home volume"
 
+      - name: Non-default identity handles read-only Managed-home binds
+        env:
+          SQUAREBOX_EVIDENCE_DIR: evidence
+        run: |
+          scripts/test-nondefault-id.sh squarebox:test
+          scripts/e2e-evidence.sh pass lifecycle.nondefault-id \
+            "A non-default Docker identity starts twice with its lifecycle-managed Bash profile mounted read-only under a writable Managed home"
+
       - name: Real stop/start and replacement reconciliation
         env:
           SQUAREBOX_EVIDENCE_DIR: evidence

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ stable v1.2 release and includes that fix.
   multiplexers alongside assistants, SDKs, editors, and TUIs.
 - Codespaces created from the custom Squarebox image include a digest-locked
   SSH server Feature, so `gh codespace ssh` can attach as documented.
+- Docker Boxes can remap `dev` to a non-default PUID/PGID even when lifecycle
+  adapters mount managed files read-only beneath the Managed home.
 
 ### Changed
 

--- a/docs/releases/v1.2.1.md
+++ b/docs/releases/v1.2.1.md
@@ -51,6 +51,8 @@ same Release.
   isolated Managed-home volume across rebuilds, and their noninteractive
   defaults can select terminal multiplexers. Codespaces also include a pinned
   SSH server Feature so `gh codespace ssh` works with the custom image.
+- Docker PUID/PGID remapping remains compatible with read-only managed files
+  mounted beneath `/home/dev`, including the lifecycle-managed Bash profile.
 - xh, just, and mise advance with reviewed amd64 and arm64 checksums.
 
 The new optional tools are not forced into an existing Selection. Run

--- a/scripts/e2e-required.tsv
+++ b/scripts/e2e-required.tsv
@@ -9,6 +9,7 @@ compose.lifecycle	Compose force-recreates the exact Candidate while Managed home
 podman.rootless	Rootless Podman maps the host user to dev, provisions Box-tier tools, and preserves Workspace and Managed-home state
 powershell.lifecycle	PowerShell lifecycle adapters parse and pass executable safety fixtures natively on Windows
 lifecycle.install-state	Lifecycle state, release identity, ownership, and static contracts pass isolated fixtures
+lifecycle.nondefault-id	A non-default Docker identity starts twice with its lifecycle-managed Bash profile mounted read-only under a writable Managed home
 artifact.fail-closed	A rejected artifact cannot reach its destination
 setup.noninteractive	Noninteractive setup exits successfully without invoking an interactive prompt
 setup.box-tier	Selected Box-tier setup completes with production capabilities and the read-only timezone mount

--- a/scripts/squarebox-entrypoint.sh
+++ b/scripts/squarebox-entrypoint.sh
@@ -32,6 +32,50 @@ validate_id() {
 	fi
 }
 
+ensure_dev_home() {
+	local passwd_entry current_home canonical_home=/home/dev
+	if ! passwd_entry="$(getent passwd dev)"; then
+		echo "squarebox: dev account is missing" >&2
+		return 1
+	fi
+	IFS=: read -r _ _ _ _ _ current_home _ <<< "$passwd_entry"
+	[ "$current_home" = "$canonical_home" ] && return 0
+
+	if ! usermod -d "$canonical_home" dev; then
+		echo "squarebox: failed to restore dev home to $canonical_home" >&2
+		return 1
+	fi
+	case "$current_home" in
+		/run/squarebox-usermod.*) rmdir "$current_home" 2>/dev/null || true ;;
+	esac
+}
+
+remap_dev_uid() {
+	local target_uid="$1" remap_home remap_status=0
+	ensure_dev_home || return 1
+
+	# GNU usermod automatically re-owns the account's current home when its UID
+	# changes. Lifecycle adapters intentionally place read-only managed-file
+	# binds below /home/dev, so that implicit traversal fails before our later
+	# best-effort chown can run. Point passwd metadata at an ephemeral root-owned
+	# directory only for the UID mutation, then restore the real Managed home.
+	remap_home="$(mktemp -d /run/squarebox-usermod.XXXXXX)"
+	if ! usermod -d "$remap_home" dev; then
+		rmdir "$remap_home" 2>/dev/null || true
+		return 1
+	fi
+	if usermod -o -u "$target_uid" dev; then
+		remap_status=0
+	else
+		remap_status=$?
+	fi
+	if ! ensure_dev_home; then
+		echo "squarebox: UID remap changed dev but its canonical home could not be restored" >&2
+		return 1
+	fi
+	return "$remap_status"
+}
+
 selection_contains() {
 	local file="$1" item="$2" value=""
 	[ -f "$file" ] || return 1
@@ -116,6 +160,10 @@ PUID="$((10#$PUID))"
 PGID="$((10#$PGID))"
 
 if [ "$(id -u)" = "0" ]; then
+	# Repair an interrupted prior remap before checking whether the numeric UID
+	# already matches. This makes a failed home-restoration attempt self-healing
+	# on the next container start instead of preserving an ephemeral passwd home.
+	ensure_dev_home
 	cur_uid="$(id -u dev)"
 	cur_gid="$(id -g dev)"
 
@@ -125,7 +173,7 @@ if [ "$(id -u)" = "0" ]; then
 		groupmod -o -g "$PGID" dev
 	fi
 	if [ "$PUID" != "$cur_uid" ]; then
-		usermod -o -u "$PUID" dev
+		remap_dev_uid "$PUID"
 	fi
 
 	# Re-own the paths dev owns only when the ids actually changed. /etc/passwd

--- a/scripts/test-nondefault-id.sh
+++ b/scripts/test-nondefault-id.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+image_ref="${1:?usage: test-nondefault-id.sh IMAGE_REF}"
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+profile="$repo_root/dotfiles/bashrc"
+suffix="${GITHUB_RUN_ID:-local}-$$"
+box="sqrbx-remap-$suffix"
+home_volume="sqrbx-remap-home-$suffix"
+profile_sha=$(sha256sum "$profile" | cut -d' ' -f1)
+
+cleanup() {
+	docker rm -f "$box" >/dev/null 2>&1 || true
+	docker volume rm "$home_volume" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+cleanup
+docker volume create "$home_volume" >/dev/null
+
+docker run --name "$box" \
+	--cap-drop=ALL --cap-add=CHOWN --cap-add=DAC_OVERRIDE \
+	--cap-add=FOWNER --cap-add=SETUID --cap-add=SETGID --cap-add=KILL \
+	-e PUID=12345 -e PGID=23456 -e EXPECTED_PROFILE_SHA="$profile_sha" \
+	-v "$home_volume:/home/dev" \
+	-v "$profile:/home/dev/.bashrc:ro" \
+	"$image_ref" bash -lc '
+		test "$(id -u)" = 12345
+		test "$(id -g)" = 23456
+		test "$HOME" = /home/dev
+		test "$(getent passwd dev | cut -d: -f6)" = /home/dev
+		test "$(stat -c %u:%g /home/dev)" = 12345:23456
+		test -r /home/dev/.bashrc
+		test "$(sha256sum /home/dev/.bashrc | cut -d" " -f1)" = "$EXPECTED_PROFILE_SHA"
+		printf "%s\n" writable > /home/dev/nondefault-id-test
+		grep -qx writable /home/dev/nondefault-id-test
+	'
+
+# Starting the same container reruns the entrypoint against its already-remapped
+# passwd entry and retained Managed home, proving the operation is idempotent.
+docker start -a "$box"
+test "$(sha256sum "$profile" | cut -d' ' -f1)" = "$profile_sha"

--- a/tests/test-provision-state.sh
+++ b/tests/test-provision-state.sh
@@ -28,6 +28,51 @@ else
 fi
 assert_true "(validate_id PUID 001000) >/dev/null 2>&1" "entrypoint accepts a positive decimal PUID"
 
+run_uid_remap_fixture() (
+	local failure_call="$1" mock_home=/home/dev mock_uid=1000 mock_calls=0
+	getent() {
+		[ "$1" = passwd ] && [ "$2" = dev ] || return 2
+		printf 'dev:x:%s:1000::%s:/bin/bash\n' "$mock_uid" "$mock_home"
+	}
+	mktemp() {
+		[ "$1" = '-d' ] || return 2
+		printf '/run/squarebox-usermod.MOCK\n'
+	}
+	rmdir() { return 0; }
+	usermod() {
+		mock_calls=$((mock_calls + 1))
+		[ "$mock_calls" != "$failure_call" ] || return 1
+		case "$1 $2" in
+			'-d /run/squarebox-usermod.MOCK') mock_home="$2" ;;
+			'-d /home/dev') mock_home="$2" ;;
+			'-o -u') mock_uid="$3" ;;
+			*) return 2 ;;
+		esac
+	}
+
+	case "$failure_call" in
+		0)
+			remap_dev_uid 12345
+			[ "$mock_uid" = 12345 ] && [ "$mock_home" = /home/dev ] && [ "$mock_calls" = 3 ]
+			;;
+		2)
+			if remap_dev_uid 12345 >/dev/null 2>&1; then return 1; fi
+			[ "$mock_uid" = 1000 ] && [ "$mock_home" = /home/dev ] && [ "$mock_calls" = 3 ]
+			;;
+		3)
+			if remap_dev_uid 12345 >/dev/null 2>&1; then return 1; fi
+			[ "$mock_uid" = 12345 ] && [ "$mock_home" = /run/squarebox-usermod.MOCK ] || return 1
+			failure_call=0
+			ensure_dev_home
+			[ "$mock_uid" = 12345 ] && [ "$mock_home" = /home/dev ] && [ "$mock_calls" = 4 ]
+			;;
+	esac
+)
+
+assert_true "run_uid_remap_fixture 0" "UID remap restores the canonical Managed home"
+assert_true "run_uid_remap_fixture 2" "failed UID mutation still restores the canonical Managed home"
+assert_true "run_uid_remap_fixture 3" "a subsequent start repairs an interrupted home restoration"
+
 OUTSIDE_SELECTION="$TMP/outside-selection"
 LINKED_SELECTION="$TMP/linked-selection"
 mkdir -p "$OUTSIDE_SELECTION"

--- a/uat-checklist.md
+++ b/uat-checklist.md
@@ -23,6 +23,7 @@ Qualification issues: [Linux desktop #126](https://github.com/SquareWaveSystems/
 - [ ] Fresh Bash installer: launch, interactive setup, exit, resume, rebuild, uninstall
 - [ ] Existing v1.1 Managed home upgrade: no repeated prompts; Selections reconcile
 - [ ] Host UID/GID other than 1000: Workspace and managed files remain host-owned
+- [ ] Non-default Docker PUID/PGID starts with lifecycle-managed read-only files mounted beneath `/home/dev`
 - [ ] Custom install path, Workspace, and Managed-home volume survive rebuild and purge correctly
 - [ ] Purge refuses an unrelated directory/container/image/volume with a colliding name
 - [ ] Docker daemon unavailable during uninstall produces a clear nonzero partial-cleanup result


### PR DESCRIPTION
## Summary

- avoid GNU usermod traversing read-only lifecycle binds beneath /home/dev during non-default UID remapping
- self-heal an interrupted passwd-home restoration on the next container start
- gate Build and Candidate publication on the production-capability regression

## Diagnosis

The v1.2.1-rc1 Linux lifecycle UAT reproduced exit 12 with PUID=12345, PGID=23456, a named Managed-home volume, and the lifecycle-managed Bash profile mounted read-only. GNU usermod implicitly re-owned the account home while changing UID and failed when it reached the read-only child bind.

The entrypoint now points passwd metadata at an ephemeral directory only during the UID mutation, restores canonical /home/dev, and repairs an interrupted restoration before checking whether the UID already matches.

## Validation

- red: exact pre-fix container topology exited 12 at usermod
- green: shared regression fixture passes twice with the production cap-drop/add set
- asserts UID/GID, passwd home, Managed-home ownership and writability, profile integrity, restart idempotence, and cleanup
- failure-injection tests cover successful remap, failed UID mutation plus restoration, and failed restoration plus next-start recovery
- all 17 executable repository test modules pass
- rebuilt image passes all 62 smoke assertions
- independent re-review found no remaining merge blocker

References #125 and #126.