### PR TITLE
Keep Dev Container defaults noninteractive

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -136,6 +136,8 @@ jobs:
             "Lifecycle state, release identity, ownership, and static contracts pass isolated fixtures"
 
       - name: Provisioning, release, and Evidence module tests
+        env:
+          SQUAREBOX_EVIDENCE_DIR: evidence
         run: |
           set -euo pipefail
           tests/test-provision-contract.sh
@@ -146,6 +148,8 @@ jobs:
           tests/test-repository-consistency.sh
           tests/test-e2e-evidence.sh
           tests/test-devcontainer-postcreate.sh
+          scripts/e2e-evidence.sh pass devcontainer.postcreate-noninteractive \
+            "Dev Container post-create defaults reconcile without prompts even when the orchestrator allocates a pseudo-TTY"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ stable v1.2 release and includes that fix.
   multiplexers alongside assistants, SDKs, editors, and TUIs.
 - Codespaces created from the custom Squarebox image include a digest-locked
   SSH server Feature, so `gh codespace ssh` can attach as documented.
+- Codespaces reconcile their post-create default Selections without opening
+  interactive pickers when the orchestrator assigns a pseudo-TTY.
 - Docker Boxes can remap `dev` to a non-default PUID/PGID even when lifecycle
   adapters mount managed files read-only beneath the Managed home.
 

--- a/docs/releases/v1.2.1.md
+++ b/docs/releases/v1.2.1.md
@@ -50,7 +50,8 @@ same Release.
 - Dev Containers retain authentication, history, and mise toolchains in an
   isolated Managed-home volume across rebuilds, and their noninteractive
   defaults can select terminal multiplexers. Codespaces also include a pinned
-  SSH server Feature so `gh codespace ssh` works with the custom image.
+  SSH server Feature so `gh codespace ssh` works with the custom image, and
+  post-create reconciliation remains noninteractive even when given a PTY.
 - Docker PUID/PGID remapping remains compatible with read-only managed files
   mounted beneath `/home/dev`, including the lifecycle-managed Bash profile.
 - xh, just, and mise advance with reviewed amd64 and arm64 checksums.

--- a/scripts/devcontainer-postcreate.sh
+++ b/scripts/devcontainer-postcreate.sh
@@ -3,10 +3,10 @@
 # Dev Containers / GitHub Codespaces.
 #
 # The interactive first-run wizard (setup.sh via .bashrc) is skipped when
-# DEVCONTAINER=1, because there is no TTY at container-create time and the
-# gum-based picker can't run. This script installs a sensible default toolset
-# non-interactively instead, by pre-seeding the selection files that
-# setup.sh reads and then running the relevant sections in --rerun mode.
+# DEVCONTAINER=1. Orchestrators may still allocate a pseudo-TTY to post-create
+# commands, so this script explicitly installs a sensible default toolset
+# without prompting by pre-seeding Selection files and reconciling only the
+# relevant sections.
 #
 # Override the defaults via containerEnv in devcontainer.json (or Codespaces
 # secrets/variables). Set a variable to an empty string to opt out of that
@@ -87,7 +87,10 @@ if [ ${#sections[@]} -eq 0 ]; then
 fi
 
 echo "squarebox: installing default toolset (${sections[*]})..."
-if ! "$SETUP" --rerun "${sections[@]}"; then
+# Codespaces and other orchestrators may allocate a pseudo-TTY to post-create
+# commands. Reconciliation is explicitly noninteractive, and closing stdin
+# makes any accidental future read fail instead of hanging container creation.
+if ! "$SETUP" --reconcile-selection "${sections[@]}" </dev/null; then
 	# setup.sh reconciles each requested Selection independently and rewrites
 	# that section to the successfully observed subset. Preserve those results:
 	# deleting every newly seeded file here would erase a successful SDK merely

--- a/scripts/e2e-required.tsv
+++ b/scripts/e2e-required.tsv
@@ -22,5 +22,6 @@ update.failure	Updater failures produce a nonzero aggregate result
 dotfiles.refresh	A stale Managed-home dotfile is safely refreshed
 dotfiles.symlink	Managed dotfile refresh rejects symlink destinations
 devcontainer.state	Dev Container configuration aligns Workspace state under /workspace and declares an isolated rebuild-stable Managed-home volume
+devcontainer.postcreate-noninteractive	Dev Container post-create defaults reconcile without prompts even when the orchestrator allocates a pseudo-TTY
 setup.rerun	The setup wrapper validates input and a noninteractive Git-section rerun succeeds
 learn.not-shipped	Disabled learn commands and hooks are absent from the default image

--- a/setup.sh
+++ b/setup.sh
@@ -2,18 +2,24 @@
 set -euo pipefail
 
 # ── Argument parsing ────────────────────────────────────────────────────
-# When called from sqrbx-setup wrapper: setup.sh --rerun [section ...]
-# When called from .bashrc first-run:   setup.sh (no args)
+# When called from sqrbx-setup wrapper:  setup.sh --rerun [section ...]
+# When called from Dev Containers:       setup.sh --reconcile-selection [section ...]
+# When called from .bashrc first-run:    setup.sh (no args)
 
 SB_RERUN=false
-SB_RECONCILE_BOX=false
+SB_RECONCILE=false
 SB_SECTIONS=()
 
 while [[ $# -gt 0 ]]; do
 	case "$1" in
 		--rerun) SB_RERUN=true; shift ;;
+		--reconcile-selection)
+			SB_RECONCILE=true
+			SB_RERUN=true
+			shift
+			;;
 		--reconcile-box)
-			SB_RECONCILE_BOX=true
+			SB_RECONCILE=true
 			SB_RERUN=true
 			SB_SECTIONS=(editors multiplexers shell)
 			shift
@@ -22,7 +28,14 @@ while [[ $# -gt 0 ]]; do
 	esac
 done
 
-# If --rerun with no specific sections, run all sections
+# Selection reconciliation is an internal, section-scoped orchestration path;
+# silently expanding it to interactive-only sections would hide caller bugs.
+if $SB_RECONCILE && [ ${#SB_SECTIONS[@]} -eq 0 ]; then
+	echo "ERROR: --reconcile-selection requires at least one section" >&2
+	exit 64
+fi
+
+# An ordinary maintainer --rerun with no specific sections runs all sections.
 if $SB_RERUN && [ ${#SB_SECTIONS[@]} -eq 0 ]; then
 	SB_SECTIONS=(git github ai editors tuis multiplexers sdks shell)
 fi
@@ -134,9 +147,10 @@ done
 export SB_TOOLS_YAML="${SQUAREBOX_TOOLS_YAML:-/usr/local/lib/squarebox/tools.yaml}"
 source "$SB_TOOL_LIB"
 
-# Detect interactive terminal
+# Reconciliation consumes existing Selection state even when an orchestrator
+# assigns a pseudo-TTY. Interactive reruns continue to prompt as before.
 INTERACTIVE=false
-if ! $SB_RECONCILE_BOX && [ -t 0 ]; then
+if ! $SB_RECONCILE && [ -t 0 ]; then
 	INTERACTIVE=true
 fi
 
@@ -456,7 +470,7 @@ _install_mise_sdk() {
 		echo "Error: mise is not installed (expected at /usr/local/bin/mise)" >&2
 		return 1
 	fi
-	if mise which "$tool" >/dev/null 2>&1 && { ! $SB_RERUN || $SB_RECONCILE_BOX; }; then
+	if mise which "$tool" >/dev/null 2>&1 && { ! $SB_RERUN || $SB_RECONCILE; }; then
 		echo "${label} already installed, skipping."
 		return 0
 	fi
@@ -611,29 +625,33 @@ for ai_tool in $(echo "$ai_choice" | tr ',' ' '); do
 done
 ai_choice=$(join_csv "${supported_ai[@]}")
 
+# npm- and mise-hosted assistants live behind mise's shims. Reconciliation
+# must observe them before deciding whether a successful install can be reused.
+_squarebox_mise_activate
+
 install_copilot() {
-	if command -v copilot &>/dev/null && { ! $SB_RERUN || $SB_RECONCILE_BOX; }; then echo "GitHub Copilot CLI already installed, skipping."; return 0; fi
+	if command -v copilot &>/dev/null && { ! $SB_RERUN || $SB_RECONCILE; }; then echo "GitHub Copilot CLI already installed, skipping."; return 0; fi
 	ensure_node_major_for_npm 22 || return 1
 	run_with_spinner "Installing/updating GitHub Copilot CLI..." npm install -g --silent @github/copilot || return 1
 	command -v copilot >/dev/null 2>&1
 }
 
 install_gemini() {
-	if command -v gemini &>/dev/null && { ! $SB_RERUN || $SB_RECONCILE_BOX; }; then echo "Google Gemini CLI already installed, skipping."; return 0; fi
+	if command -v gemini &>/dev/null && { ! $SB_RERUN || $SB_RECONCILE; }; then echo "Google Gemini CLI already installed, skipping."; return 0; fi
 	ensure_node_for_npm || return 1
 	run_with_spinner "Installing/updating Google Gemini CLI..." npm install -g --silent @google/gemini-cli || return 1
 	command -v gemini >/dev/null 2>&1
 }
 
 install_codex() {
-	if command -v codex &>/dev/null && { ! $SB_RERUN || $SB_RECONCILE_BOX; }; then echo "OpenAI Codex CLI already installed, skipping."; return 0; fi
+	if command -v codex &>/dev/null && { ! $SB_RERUN || $SB_RECONCILE; }; then echo "OpenAI Codex CLI already installed, skipping."; return 0; fi
 	ensure_node_for_npm || return 1
 	run_with_spinner "Installing/updating OpenAI Codex CLI..." npm install -g --silent @openai/codex || return 1
 	command -v codex >/dev/null 2>&1
 }
 
 install_pi() {
-	if command -v pi &>/dev/null && { ! $SB_RERUN || $SB_RECONCILE_BOX; }; then echo "Pi Coding Agent already installed, skipping."; return 0; fi
+	if command -v pi &>/dev/null && { ! $SB_RERUN || $SB_RECONCILE; }; then echo "Pi Coding Agent already installed, skipping."; return 0; fi
 	ensure_node_for_npm || return 1
 	# --ignore-scripts is the upstream-recommended install flag (see pi.dev).
 	run_with_spinner "Installing/updating Pi Coding Agent..." npm install -g --silent --ignore-scripts @earendil-works/pi-coding-agent || return 1
@@ -641,14 +659,14 @@ install_pi() {
 }
 
 install_omp() {
-	if command -v omp &>/dev/null && { ! $SB_RERUN || $SB_RECONCILE_BOX; }; then echo "Oh My Pi already installed, skipping."; return 0; fi
+	if command -v omp &>/dev/null && { ! $SB_RERUN || $SB_RECONCILE; }; then echo "Oh My Pi already installed, skipping."; return 0; fi
 	run_with_spinner "Installing/updating Oh My Pi (via mise)..." mise use -g github:can1357/oh-my-pi || return 1
 	_squarebox_mise_activate
 	command -v omp >/dev/null 2>&1
 }
 
 install_claude() {
-	if command -v claude >/dev/null 2>&1 && { ! $SB_RERUN || $SB_RECONCILE_BOX; }; then
+	if command -v claude >/dev/null 2>&1 && { ! $SB_RERUN || $SB_RECONCILE; }; then
 		echo "Claude Code already installed, skipping."
 		return 0
 	fi
@@ -683,7 +701,7 @@ for ai_tool in $(echo "$ai_choice" | tr ',' ' '); do
 			run_with_spinner "Installing/updating Claude Code..." install_claude && ai_ok=true
 			;;
 		opencode)
-			if command -v opencode &>/dev/null && { ! $SB_RERUN || $SB_RECONCILE_BOX; }; then
+			if command -v opencode &>/dev/null && { ! $SB_RERUN || $SB_RECONCILE; }; then
 				echo "OpenCode already installed, skipping."
 				ai_ok=true
 			else

--- a/tests/test-devcontainer-postcreate.sh
+++ b/tests/test-devcontainer-postcreate.sh
@@ -13,6 +13,8 @@ mkdir -p "$STATE" "$HOME_DIR"
 cat > "$FAKE_SETUP" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+[ ! -t 0 ]
+if IFS= read -r _unexpected_input; then exit 97; fi
 printf '%s\n' "$*" > "$SQUAREBOX_FAKE_SETUP_CALL"
 # Model independent setup outcomes: assistant failed and was not committed;
 # SDK and multiplexer succeeded and remain observed/selected.
@@ -66,7 +68,7 @@ if HOME="$HOME_DIR" SQUAREBOX_STATE_DIR="$STATE" \
 	echo "FAIL: post-create accepted a failed setup" >&2
 	exit 1
 fi
-grep -qx -- '--rerun ai sdks multiplexers' "$TMP/setup.call"
+grep -qx -- '--reconcile-selection ai sdks multiplexers' "$TMP/setup.call"
 test -f "$STATE/ai-tool" && test ! -s "$STATE/ai-tool"
 grep -qx node "$STATE/sdks"
 grep -qx zellij "$STATE/multiplexer"
@@ -78,6 +80,8 @@ printf 'tmux\n' > "$STATE/multiplexer"
 cat > "$FAKE_SETUP" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+[ ! -t 0 ]
+if IFS= read -r _unexpected_input; then exit 97; fi
 grep -qx python "$SQUAREBOX_STATE_DIR/sdks"
 grep -qx tmux "$SQUAREBOX_STATE_DIR/multiplexer"
 EOF
@@ -91,5 +95,78 @@ HOME="$HOME_DIR" SQUAREBOX_STATE_DIR="$STATE" \
 grep -qx python "$STATE/sdks"
 grep -qx tmux "$STATE/multiplexer"
 test -e "$HOME_DIR/.squarebox-setup-done"
+
+# Codespaces runs postCreateCommand with a pseudo-TTY. Prove the call site
+# closes stdin independently of setup's reconciliation-mode implementation.
+PTY_STATE="$TMP/pty-state"
+PTY_HOME="$TMP/pty-home"
+PTY_SETUP="$TMP/pty-setup.sh"
+mkdir -p "$PTY_STATE" "$PTY_HOME"
+cat > "$PTY_SETUP" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[ ! -t 0 ]
+if IFS= read -r _unexpected_input; then exit 97; fi
+test "$*" = '--reconcile-selection ai sdks'
+grep -qx claude "$SQUAREBOX_STATE_DIR/ai-tool"
+grep -qx node "$SQUAREBOX_STATE_DIR/sdks"
+printf 'called\n' > "$SQUAREBOX_FAKE_SETUP_CALL"
+EOF
+chmod +x "$PTY_SETUP"
+timeout 5s script -qec "env HOME='$PTY_HOME' SQUAREBOX_STATE_DIR='$PTY_STATE' SQUAREBOX_SETUP_SCRIPT='$PTY_SETUP' SQUAREBOX_FAKE_SETUP_CALL='$TMP/pty-setup.called' SQUAREBOX_DC_AI=claude SQUAREBOX_DC_SDKS=node SQUAREBOX_DC_EDITORS= SQUAREBOX_DC_TUIS= SQUAREBOX_DC_MULTIPLEXERS= bash '$ROOT/scripts/devcontainer-postcreate.sh'" /dev/null \
+	>"$TMP/pty-postcreate.out" 2>&1
+test -e "$TMP/pty-setup.called"
+test -e "$PTY_HOME/.squarebox-setup-done"
+
+# Independently exercise the real reconciliation mode under a live PTY and
+# without stdin redirection. Observed npm- and mise-hosted assistants must be
+# found through mise shims, with no Gum prompt or reinstall command.
+RECON_STATE="$TMP/reconcile-state"
+RECON_HOME="$TMP/reconcile-home"
+RECON_BIN="$TMP/reconcile-bin"
+RECON_SHIMS="$RECON_HOME/.local/share/mise/shims"
+RECON_TOOL_LIB="$TMP/reconcile-tool-lib.sh"
+mkdir -p "$RECON_STATE" "$RECON_HOME" "$RECON_BIN" "$RECON_SHIMS"
+printf 'copilot,omp\n' > "$RECON_STATE/ai-tool"
+printf 'node\n' > "$RECON_STATE/sdks"
+printf ':\n' > "$RECON_TOOL_LIB"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$RECON_SHIMS/copilot"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$RECON_SHIMS/omp"
+cat > "$RECON_BIN/mise" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$SQUAREBOX_FAKE_MISE_LOG"
+case "${1:-}" in
+	activate) printf 'export PATH="%s/.local/share/mise/shims:$PATH"\n' "$HOME" ;;
+	which) exit 0 ;;
+	use) printf 'called\n' > "$SQUAREBOX_FAKE_INSTALL_CALLED"; exit 99 ;;
+	*) exit 0 ;;
+esac
+EOF
+cat > "$RECON_BIN/npm" <<'EOF'
+#!/usr/bin/env bash
+printf 'called\n' > "$SQUAREBOX_FAKE_INSTALL_CALLED"
+exit 99
+EOF
+cat > "$RECON_BIN/gum" <<'EOF'
+#!/usr/bin/env bash
+printf 'called\n' > "$SQUAREBOX_FAKE_GUM_CALLED"
+exit 99
+EOF
+chmod +x "$RECON_BIN/mise" "$RECON_BIN/npm" "$RECON_BIN/gum" \
+	"$RECON_SHIMS/copilot" "$RECON_SHIMS/omp"
+
+timeout 5s script -qec "env HOME='$RECON_HOME' SQUAREBOX_STATE_DIR='$RECON_STATE' SQUAREBOX_TOOL_LIB='$RECON_TOOL_LIB' SQUAREBOX_TOOLS_YAML=/dev/null SQUAREBOX_FAKE_GUM_CALLED='$TMP/gum.called' SQUAREBOX_FAKE_INSTALL_CALLED='$TMP/install.called' SQUAREBOX_FAKE_MISE_LOG='$TMP/mise.log' PATH='$RECON_BIN:/usr/bin:/bin' bash '$ROOT/setup.sh' --reconcile-selection ai sdks" /dev/null \
+	>"$TMP/tty-reconcile.out" 2>&1
+test ! -e "$TMP/gum.called"
+test ! -e "$TMP/install.called"
+grep -qx 'copilot,omp' "$RECON_STATE/ai-tool"
+grep -qx node "$RECON_STATE/sdks"
+! grep -q '^use ' "$TMP/mise.log"
+
+if bash "$ROOT/setup.sh" --reconcile-selection >"$TMP/reconcile-no-sections.out" 2>&1; then
+	echo "FAIL: selection reconciliation accepted no sections" >&2
+	exit 1
+fi
+grep -q -- '--reconcile-selection requires at least one section' "$TMP/reconcile-no-sections.out"
 
 echo "PASS: Dev Container provisioning preserves independent section outcomes and prior Selections"


### PR DESCRIPTION
## Summary

- add a section-scoped Selection reconciliation mode that never prompts, even with a PTY
- close postCreate stdin so accidental reads fail instead of hanging orchestration
- activate mise shims before deciding whether persisted assistant installs can be reused
- add a required Candidate Evidence assertion for the exact PTY postCreate contract

## Diagnosis

Real v1.2.1-rc2 Codespaces UAT pre-seeded claude and node, then setup.sh --rerun ai sdks inherited the Codespaces PTY. The rerun flag selected sections but did not disable interactive mode, so Gum opened the AI picker and postCreate hung before installing either default.

## Validation

- red: deterministic PTY boundary reproduced the old rerun invocation and interactive path
- PTY postCreate fixture independently proves setup receives closed stdin and EOF
- direct real setup reconciliation under a PTY proves Gum is not invoked
- custom Copilot and OMP shims prove npm/mise installs are not repeated
- bare reconciliation fails closed without explicit sections
- real Dev Container CLI 0.87.0 first creation installed Claude 2.1.220 and Node 26.5.1
- real replacement retained Workspace/Managed-home markers and skipped both observed tools
- all 17 executable repository test modules pass
- disposable container and exact Managed-home volume were removed
- independent review found no remaining implementation blocker

References #125 and #130.