### PR TITLE
Roll back failed Dev Container defaults

### DIFF
--- a/scripts/devcontainer-postcreate.sh
+++ b/scripts/devcontainer-postcreate.sh
@@ -61,6 +61,8 @@ TUIS=${SQUAREBOX_DC_TUIS-}
 MULTIPLEXERS=${SQUAREBOX_DC_MULTIPLEXERS-}
 
 sections=()
+new_selection_files=()
+new_editor_default=false
 
 # seed <config-file> <value> <section>
 # Writes the selection file only if absent, so a user's prior sqrbx-setup
@@ -71,6 +73,10 @@ seed() {
 	[ -z "$value" ] && return 0
 	if [ ! -f "$CONFIG_DIR/$file" ]; then
 		printf '%s\n' "$value" > "$CONFIG_DIR/$file"
+		new_selection_files+=("$file")
+		if [ "$file" = editors ] && [ ! -e "$CONFIG_DIR/editor-default" ]; then
+			new_editor_default=true
+		fi
 	fi
 	sections+=("$section")
 }
@@ -90,11 +96,31 @@ echo "squarebox: installing default toolset (${sections[*]})..."
 # Codespaces and other orchestrators may allocate a pseudo-TTY to post-create
 # commands. Reconciliation is explicitly noninteractive, and closing stdin
 # makes any accidental future read fail instead of hanging container creation.
-if ! "$SETUP" --reconcile-selection "${sections[@]}" </dev/null; then
+new_selection_csv=$(IFS=,; printf '%s' "${new_selection_files[*]}")
+if ! SQUAREBOX_RECONCILE_NEW_SELECTIONS="$new_selection_csv" \
+	"$SETUP" --reconcile-selection "${sections[@]}" </dev/null; then
 	# setup.sh reconciles each requested Selection independently and rewrites
-	# that section to the successfully observed subset. Preserve those results:
-	# deleting every newly seeded file here would erase a successful SDK merely
-	# because an unrelated assistant failed later in the same run.
+	# that section to the successfully observed subset. Remove only empty files
+	# that this invocation seeded: successful subsets remain committed, prior
+	# user Selections are untouched, and a failed new default can retry later.
+	for selection_file in "${new_selection_files[@]}"; do
+		selection_path="$CONFIG_DIR/$selection_file"
+		if [ -f "$selection_path" ]; then
+			if grep -q '[^[:space:]]' -- "$selection_path"; then
+				continue
+			else
+				grep_rc=$?
+			fi
+			if [ "$grep_rc" -eq 1 ]; then
+				rm -f -- "$selection_path"
+				if [ "$selection_file" = editors ] && $new_editor_default; then
+					rm -f -- "$CONFIG_DIR/editor-default"
+				fi
+			else
+				echo "squarebox: unable to inspect failed Selection: $selection_path" >&2
+			fi
+		fi
+	done
 	echo "squarebox: default tool provisioning failed" >&2
 	exit 1
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -89,6 +89,17 @@ should_run() {
 	return 1
 }
 
+# postCreate seeds defaults into otherwise absent Selection files so this
+# reconciliation pass can consume them. Those values are requested choices,
+# not prior user Selections, and must not be retained when installation fails.
+reconcile_selection_was_newly_seeded() {
+	$SB_RECONCILE || return 1
+	case ",${SQUAREBOX_RECONCILE_NEW_SELECTIONS-}," in
+		*",$1,"*) return 0 ;;
+	esac
+	return 1
+}
+
 SB_TMPDIR=$(mktemp -d)
 export SB_TMPDIR
 trap 'rm -rf "$SB_TMPDIR"' EXIT
@@ -616,6 +627,8 @@ else
 	ai_choice="claude"
 fi
 
+reconcile_selection_was_newly_seeded ai-tool && ai_prev=""
+
 supported_ai=()
 for ai_tool in $(echo "$ai_choice" | tr ',' ' '); do
 	case "$ai_tool" in
@@ -842,6 +855,8 @@ else
 	echo "Skipping editor selection (non-interactive)"
 	editor_list=""
 fi
+
+reconcile_selection_was_newly_seeded editors && editor_prev=""
 
 if ! $editor_cancelled; then
 
@@ -1153,6 +1168,8 @@ else
 	tui_list=""
 fi
 
+reconcile_selection_was_newly_seeded tuis && tui_prev=""
+
 if ! $tui_cancelled; then
 
 install_lazygit() {
@@ -1302,6 +1319,8 @@ else
 	echo "Skipping multiplexer selection (non-interactive)"
 	mux_list=""
 fi
+
+reconcile_selection_was_newly_seeded multiplexer && mux_prev=""
 
 if ! $mux_cancelled; then
 
@@ -1867,6 +1886,8 @@ else
 	echo "Skipping SDK selection (non-interactive)"
 	sdk_list=""
 fi
+
+reconcile_selection_was_newly_seeded sdks && sdk_prev=""
 
 if ! $sdk_cancelled; then
 

--- a/tests/test-devcontainer-postcreate.sh
+++ b/tests/test-devcontainer-postcreate.sh
@@ -69,7 +69,7 @@ if HOME="$HOME_DIR" SQUAREBOX_STATE_DIR="$STATE" \
 	exit 1
 fi
 grep -qx -- '--reconcile-selection ai sdks multiplexers' "$TMP/setup.call"
-test -f "$STATE/ai-tool" && test ! -s "$STATE/ai-tool"
+test ! -e "$STATE/ai-tool"
 grep -qx node "$STATE/sdks"
 grep -qx zellij "$STATE/multiplexer"
 test ! -e "$HOME_DIR/.squarebox-setup-done"
@@ -168,5 +168,128 @@ if bash "$ROOT/setup.sh" --reconcile-selection >"$TMP/reconcile-no-sections.out"
 	exit 1
 fi
 grep -q -- '--reconcile-selection requires at least one section' "$TMP/reconcile-no-sections.out"
+
+# Exercise the real postCreate -> setup transaction for a newly seeded default.
+# A failed install must leave the Selection absent so the next postCreate can
+# retry it, while a pre-existing user Selection must remain preserved.
+DEFAULT_FAILURE_STATE="$TMP/default-failure-state"
+DEFAULT_FAILURE_HOME="$TMP/default-failure-home"
+DEFAULT_FAILURE_BIN="$TMP/default-failure-bin"
+DEFAULT_FAILURE_TOOL_LIB="$TMP/default-failure-tool-lib.sh"
+DEFAULT_FAILURE_LOG="$TMP/default-failure-install.log"
+mkdir -p "$DEFAULT_FAILURE_STATE" "$DEFAULT_FAILURE_HOME" "$DEFAULT_FAILURE_BIN"
+cat > "$DEFAULT_FAILURE_TOOL_LIB" <<'EOF'
+# Keep the probe independent of optional tools installed on the test host.
+command() {
+	if [ "${1:-}" = -v ]; then
+		case "${2:-}" in
+			yazi|ya|elio|hx)
+				[ -x "$SQUAREBOX_FAKE_BIN/${2}" ] || return 1
+				;;
+		esac
+	fi
+	builtin command "$@"
+}
+
+sb_install() {
+	printf '%s\n' "$*" >> "$SQUAREBOX_FAKE_INSTALL_LOG"
+	if [ "$SQUAREBOX_FAKE_INSTALL_MODE" = success ]; then
+		case "$1" in
+			yazi)
+				for tool in yazi ya; do
+					printf '#!/usr/bin/env bash\nexit 0\n' > "$SQUAREBOX_FAKE_BIN/$tool"
+					chmod +x "$SQUAREBOX_FAKE_BIN/$tool"
+				done
+				return 0
+				;;
+			helix)
+				printf '#!/usr/bin/env bash\nexit 0\n' > "$SQUAREBOX_FAKE_BIN/hx"
+				chmod +x "$SQUAREBOX_FAKE_BIN/hx"
+				mkdir -p "$HOME/.config/helix/runtime"
+				return 0
+				;;
+		esac
+	fi
+	return 1
+}
+EOF
+
+run_default() {
+	local mode=$1 state=${2:-$DEFAULT_FAILURE_STATE} home=${3:-$DEFAULT_FAILURE_HOME}
+	HOME="$home" \
+		PATH="$DEFAULT_FAILURE_BIN:/usr/bin:/bin" \
+		SQUAREBOX_STATE_DIR="$state" \
+		SQUAREBOX_SETUP_SCRIPT="$ROOT/setup.sh" \
+		SQUAREBOX_TOOL_LIB="$DEFAULT_FAILURE_TOOL_LIB" \
+		SQUAREBOX_TOOLS_YAML=/dev/null \
+		SQUAREBOX_FAKE_BIN="$DEFAULT_FAILURE_BIN" \
+		SQUAREBOX_FAKE_INSTALL_MODE="$mode" \
+		SQUAREBOX_FAKE_INSTALL_LOG="$DEFAULT_FAILURE_LOG" \
+		SQUAREBOX_DC_AI= SQUAREBOX_DC_SDKS= \
+		SQUAREBOX_DC_EDITORS= SQUAREBOX_DC_TUIS=yazi \
+		SQUAREBOX_DC_MULTIPLEXERS= \
+		bash "$ROOT/scripts/devcontainer-postcreate.sh" \
+		>"$TMP/default-$mode.out" 2>&1
+}
+
+if run_default fail; then
+	echo "FAIL: post-create accepted a failed newly seeded default" >&2
+	exit 1
+fi
+test ! -e "$DEFAULT_FAILURE_STATE/tuis"
+run_default success
+grep -qx yazi "$DEFAULT_FAILURE_STATE/tuis"
+test -x "$DEFAULT_FAILURE_BIN/yazi"
+test -x "$DEFAULT_FAILURE_BIN/ya"
+test "$(wc -l < "$DEFAULT_FAILURE_LOG")" -eq 2
+test -e "$DEFAULT_FAILURE_HOME/.squarebox-setup-done"
+
+rm -f -- "$DEFAULT_FAILURE_BIN/yazi" "$DEFAULT_FAILURE_BIN/ya"
+PRIOR_STATE="$TMP/prior-selection-state"
+PRIOR_HOME="$TMP/prior-selection-home"
+mkdir -p "$PRIOR_STATE" "$PRIOR_HOME"
+printf 'elio\n' > "$PRIOR_STATE/tuis"
+if run_default fail "$PRIOR_STATE" "$PRIOR_HOME"; then
+	echo "FAIL: post-create accepted a failed prior Selection" >&2
+	exit 1
+fi
+grep -qx elio "$PRIOR_STATE/tuis"
+test "$(wc -l < "$DEFAULT_FAILURE_LOG")" -eq 3
+tail -n 1 "$DEFAULT_FAILURE_LOG" | grep -qx 'elio latest'
+test ! -e "$PRIOR_HOME/.squarebox-setup-done"
+
+EDITOR_FAILURE_STATE="$TMP/editor-failure-state"
+EDITOR_FAILURE_HOME="$TMP/editor-failure-home"
+EDITOR_FAILURE_LOG="$TMP/editor-failure-install.log"
+mkdir -p "$EDITOR_FAILURE_STATE" "$EDITOR_FAILURE_HOME"
+run_editor_default() {
+	local mode=$1
+	HOME="$EDITOR_FAILURE_HOME" \
+		PATH="$DEFAULT_FAILURE_BIN:/usr/bin:/bin" \
+		SQUAREBOX_STATE_DIR="$EDITOR_FAILURE_STATE" \
+		SQUAREBOX_SETUP_SCRIPT="$ROOT/setup.sh" \
+		SQUAREBOX_TOOL_LIB="$DEFAULT_FAILURE_TOOL_LIB" \
+		SQUAREBOX_TOOLS_YAML=/dev/null \
+		SQUAREBOX_FAKE_BIN="$DEFAULT_FAILURE_BIN" \
+		SQUAREBOX_FAKE_INSTALL_MODE="$mode" \
+		SQUAREBOX_FAKE_INSTALL_LOG="$EDITOR_FAILURE_LOG" \
+		SQUAREBOX_DC_AI= SQUAREBOX_DC_SDKS= \
+		SQUAREBOX_DC_EDITORS=helix SQUAREBOX_DC_TUIS= \
+		SQUAREBOX_DC_MULTIPLEXERS= \
+		bash "$ROOT/scripts/devcontainer-postcreate.sh" \
+		>"$TMP/editor-$mode.out" 2>&1
+}
+
+if run_editor_default fail; then
+	echo "FAIL: post-create accepted a failed newly seeded editor" >&2
+	exit 1
+fi
+test ! -e "$EDITOR_FAILURE_STATE/editors"
+test ! -e "$EDITOR_FAILURE_STATE/editor-default"
+run_editor_default success
+grep -qx helix "$EDITOR_FAILURE_STATE/editors"
+grep -qx hx "$EDITOR_FAILURE_STATE/editor-default"
+test -e "$EDITOR_FAILURE_HOME/.squarebox-setup-done"
+test "$(wc -l < "$EDITOR_FAILURE_LOG")" -eq 2
 
 echo "PASS: Dev Container provisioning preserves independent section outcomes and prior Selections"


### PR DESCRIPTION
## Summary

- distinguish newly seeded Dev Container defaults from prior user Selections during reconciliation
- roll back failed new defaults while preserving successful independent sections and existing choices
- roll back a newly created `editor-default` companion when a new editor set fails, so a successful retry chooses the installed editor
- add real postCreate → setup fail/retry coverage for Yazi and Helix plus prior-Selection preservation

## Root cause

`devcontainer-postcreate.sh` wrote an absent default into Workspace Selection before invoking setup. Setup then treated that value as a prior user choice, so a failed install retained it even while reporting that the new Selection was not committed.

The fix passes the known-new Selection filenames into reconciliation. Setup still consumes the requested values, but excludes them from failure retention. PostCreate removes only newly seeded files that reconcile empty; successful subsets and prior user Selections remain intact.

## Impact

This clears the v1.2.1-rc3 Codespaces NO-PROMOTE blocker recorded on #130. A failed default no longer claims an unobserved tool, and a later postCreate can retry cleanly.

## Validation

- all 17 executable repository test modules pass
- `bash -n` and `git diff --check`
- Docker image build with `SQUAREBOX_VERSION=dev`
- smoke E2E: 62/62 pass
- independent read-only design review: no blockers

rc3 remains immutable and must not be promoted. After merge, qualification restarts with protected v1.2.1-rc4.
