### PR TITLE
Document v1.2.1 platform qualification waivers

### DIFF
--- a/.out-of-scope/v1.2.1-external-platform-qualification.md
+++ b/.out-of-scope/v1.2.1-external-platform-qualification.md
@@ -1,32 +1,50 @@
-# v1.2.1 external platform qualification
+# v1.2.1 external platform qualification waiver
 
-Squarebox v1.2.1 is being released on a best-effort qualification basis without
-manual Fedora SELinux/rootless Podman, macOS Docker Desktop, native Windows, or
-physical arm64 runs.
+Release owner Brett Kinny accepted on 2026-08-01 that the immutable v1.2.1
+Release may proceed without manual Fedora SELinux/rootless Podman, macOS Docker
+Desktop, native Windows PowerShell 7 and Git Bash, or physical arm64 runs. These
+criteria are waived, not passed.
 
 ## Why this is out of scope
 
-The release has completed its automated multi-architecture Candidate suite,
-artifact and signature verification, real Linux Docker lifecycle testing on
-physical amd64, genuine non-1000 Linux testing in a KVM guest, Codespaces
-create/rebuild testing, and retained-v1.1-home migration testing. The release
-owner accepted the residual host-integration risk rather than delaying v1.2.1
-until every external operating system and physical architecture was available.
+This is a permanent decision for the v1.2.1 Release identity once published,
+not a reusable rejection of platform qualification. It is recorded here
+because the version-specific enhancement-style UAT issues are being resolved
+as `wontfix`. This record must never be used to deduplicate or reject
+qualification work for a later Release. Each later Release must create fresh
+qualification issues and reassess its manual gates.
 
-This is a version-specific qualification waiver, not a statement that Fedora,
-Podman, macOS, Windows, or arm64 support has been removed. Failures reported on
-those supported paths remain valid bugs. Future Releases should create fresh
-qualification issues and may reinstate any of these manual gates when suitable
-hosts are available.
+Prerelease qualification through `v1.2.1-rc5`, source
+`8f56f759acdf735c50e1bd0464dd852c28618deb` and image digest
+`sha256:861dd7c2ae0e69ae18641bb3817ed0647570c5527b3b3354bfc8f073817b55f5`,
+completed the automated multi-architecture Candidate suite, artifact and
+signature verification, real physical-amd64 Linux Docker lifecycle testing,
+genuine UID/GID 2000 Linux testing in a KVM guest, and Codespaces
+create/rebuild testing. A mechanical retained-v1.1-home migration also passed
+with synthetic authentication, Selection, and Workspace markers; real
+authentication and prompt behavior are not claimed by that evidence.
 
-Physical arm64 remains covered by the automated exact-Candidate arm64 build and
-emulated smoke evidence, but v1.2.1 does not claim a native physical-arm64 UAT
-pass. Final publication still requires exact-digest physical amd64 testing and
-all automated Evidence.
+The final protected `v1.2.1` Candidate does not exist yet. It must repeat every
+automated build, Evidence, artifact, signature, and emulated-arm64 gate. It also
+still requires desktop VS Code Dev Containers UI evidence under #130, native
+physical-amd64 exact-digest qualification, draft verification, protected
+environment approval, immutable publication verification, alias checks, and
+the non-rewind proof under #131.
+
+## Affected release criteria
+
+For v1.2.1 only, #125 no longer requires #127, #128, or #129 to produce a manual
+pass, and no longer requires the physical-arm64 portion of #131. All other #125
+and #131 criteria remain required.
+
+This waiver does not remove or change existing platform support status.
+Podman remains experimental. Failures reported on any documented path remain
+valid bugs.
 
 ## Prior requests
 
-- #127 — Qualify v1.2 rootless Podman on Fedora SELinux
-- #128 — Qualify v1.2 on macOS Docker Desktop
-- #129 — Qualify v1.2 Windows PowerShell and Git Bash lifecycle
-- #131 — Qualify the final v1.2 Candidate on physical amd64 and arm64
+- #127 — Fedora SELinux/rootless Podman manual qualification
+- #128 — macOS Docker Desktop manual qualification
+- #129 — Windows PowerShell 7 and Git Bash manual qualification
+- #131 — physical-arm64 criterion only; the issue remains open for every other
+  final-Candidate and publication criterion

--- a/.out-of-scope/v1.2.1-external-platform-qualification.md
+++ b/.out-of-scope/v1.2.1-external-platform-qualification.md
@@ -9,10 +9,11 @@ criteria are waived, not passed.
 
 This is a permanent decision for the v1.2.1 Release identity once published,
 not a reusable rejection of platform qualification. It is recorded here
-because the version-specific enhancement-style UAT issues are being resolved
-as `wontfix`. This record must never be used to deduplicate or reject
-qualification work for a later Release. Each later Release must create fresh
-qualification issues and reassess its manual gates.
+because #127, #128, and #129 will be resolved as `wontfix`. Only #131's
+physical-arm64 criterion is waived; #131 remains open. This record must never
+be used to deduplicate or reject qualification work for a later Release. Each
+later Release must create fresh qualification issues and reassess its manual
+gates.
 
 Prerelease qualification through `v1.2.1-rc5`, source
 `8f56f759acdf735c50e1bd0464dd852c28618deb` and image digest

--- a/.out-of-scope/v1.2.1-external-platform-qualification.md
+++ b/.out-of-scope/v1.2.1-external-platform-qualification.md
@@ -1,0 +1,32 @@
+# v1.2.1 external platform qualification
+
+Squarebox v1.2.1 is being released on a best-effort qualification basis without
+manual Fedora SELinux/rootless Podman, macOS Docker Desktop, native Windows, or
+physical arm64 runs.
+
+## Why this is out of scope
+
+The release has completed its automated multi-architecture Candidate suite,
+artifact and signature verification, real Linux Docker lifecycle testing on
+physical amd64, genuine non-1000 Linux testing in a KVM guest, Codespaces
+create/rebuild testing, and retained-v1.1-home migration testing. The release
+owner accepted the residual host-integration risk rather than delaying v1.2.1
+until every external operating system and physical architecture was available.
+
+This is a version-specific qualification waiver, not a statement that Fedora,
+Podman, macOS, Windows, or arm64 support has been removed. Failures reported on
+those supported paths remain valid bugs. Future Releases should create fresh
+qualification issues and may reinstate any of these manual gates when suitable
+hosts are available.
+
+Physical arm64 remains covered by the automated exact-Candidate arm64 build and
+emulated smoke evidence, but v1.2.1 does not claim a native physical-arm64 UAT
+pass. Final publication still requires exact-digest physical amd64 testing and
+all automated Evidence.
+
+## Prior requests
+
+- #127 — Qualify v1.2 rootless Podman on Fedora SELinux
+- #128 — Qualify v1.2 on macOS Docker Desktop
+- #129 — Qualify v1.2 Windows PowerShell and Git Bash lifecycle
+- #131 — Qualify the final v1.2 Candidate on physical amd64 and arm64


### PR DESCRIPTION
## Summary

- records Brett Kinny's 2026-08-01 version-scoped waiver for #127, #128, #129, and only the physical-arm64 criterion of #131
- explicitly preserves existing platform support levels and prevents this waiver from transferring to later Releases
- keeps #130 UI, final physical amd64, automated Candidate Evidence, approval, attestation, aliases, and non-rewind required

## Why

The external hosts are unavailable for v1.2.1 and the release owner chose not to delay publication after the available rc5 automated, Linux, Codespaces, migration, and genuine non-1000 qualification passed. Because #127-#129 will be resolved as `wontfix`, the triage workflow requires a durable version-specific record; #131 remains open and only its physical-arm64 criterion is waived.

## Validation

- `git diff --check`
- two independent reviews against the `.out-of-scope/` format and issues #125, #127, #128, #129, #130, and the physical-arm64-only boundary in #131
- corrected review findings so #131 remains open for all non-waived final-Candidate and publication duties