### PR TITLE
Fix Rust SDK availability probe

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -476,18 +476,20 @@ _install_mise_sdk_inner() {
 }
 
 _install_mise_sdk() {
-	local tool="$1" label="$2" version="${3:-latest}"
+	# A mise tool name is not always one of the executables it provides (for
+	# example, the rust toolchain exposes rustc and cargo, not `rust`).
+	local tool="$1" label="$2" version="${3:-latest}" probe="${4:-$1}"
 	if ! command -v mise >/dev/null 2>&1; then
 		echo "Error: mise is not installed (expected at /usr/local/bin/mise)" >&2
 		return 1
 	fi
-	if mise which "$tool" >/dev/null 2>&1 && { ! $SB_RERUN || $SB_RECONCILE; }; then
+	if mise which "$probe" >/dev/null 2>&1 && { ! $SB_RERUN || $SB_RECONCILE; }; then
 		echo "${label} already installed, skipping."
 		return 0
 	fi
 	run_with_spinner "Installing/updating ${label} (via mise)..." _install_mise_sdk_inner "$tool" "$version" || return 1
 	_squarebox_mise_activate
-	if ! mise which "$tool" >/dev/null 2>&1; then
+	if ! mise which "$probe" >/dev/null 2>&1; then
 		echo "Error: ${label} not available after mise install" >&2
 		return 1
 	fi
@@ -497,7 +499,7 @@ install_node()   { _install_mise_sdk node   "Node.js"; }
 install_python() { _install_mise_sdk python "Python"; }
 install_go()     { _install_mise_sdk go     "Go"; }
 install_dotnet() { _install_mise_sdk dotnet ".NET"; }
-install_rust()   { _install_mise_sdk rust   "Rust"; }
+install_rust()   { _install_mise_sdk rust   "Rust" latest rustc; }
 
 # Ensure Node.js is available for npm-based AI tools
 ensure_node_for_npm() {

--- a/tests/test-provision-install-failures.sh
+++ b/tests/test-provision-install-failures.sh
@@ -61,6 +61,13 @@ chmod +x "$FIXTURE_BIN/gum"
 cat > "$FIXTURE_BIN/mise" <<-'MISE'
 	#!/bin/bash
 	printf '%s\n' "$*" >> "$MISE_CALLS"
+	if [ "${MISE_MODE:-}" = rust-success ]; then
+		case "$*" in
+			"use -g rust@latest") touch "$MISE_RUST_INSTALLED"; exit 0 ;;
+			"activate bash --shims") exit 0 ;;
+			"which rustc") [ -e "$MISE_RUST_INSTALLED" ]; exit ;;
+		esac
+	fi
 	exit "${MISE_RC:-42}"
 MISE
 chmod +x "$FIXTURE_BIN/mise"
@@ -133,6 +140,8 @@ run_selected_section() {
 		ATOMIC_FAILURE_CALLS="$case_dir/atomic-failure.calls" \
 		NETWORK_CALLS="$case_dir/network.calls" \
 		MISE_CALLS="$case_dir/mise.calls" \
+		MISE_MODE="${MISE_MODE:-}" \
+		MISE_RUST_INSTALLED="$case_dir/rust.installed" \
 		FAKE_GUM_SELECTION="$selection" \
 		PATH="$FIXTURE_BIN" \
 		/usr/bin/script -qec "/bin/bash '$ROOT/setup.sh' --rerun '$section'" /dev/null \
@@ -206,6 +215,13 @@ assert_true "[ \"\$(cat '$OMP_CASE/setup.rc')\" -ne 0 ] && [ -z \"\$(cat '$OMP_C
 	"Oh My Pi mise failure propagates without committing a Selection"
 assert_true "grep -Fqx 'use -g github:can1357/oh-my-pi' '$OMP_CASE/mise.calls'" \
 	"Oh My Pi failure audit exercises its mise installer"
+
+RUST_CASE="$TMP/rust"
+MISE_MODE=rust-success run_selected_section sdks Rust "$RUST_CASE" 0
+assert_true "[ \"\$(cat '$RUST_CASE/setup.rc')\" -eq 0 ] && [ \"\$(cat '$RUST_CASE/state/sdks')\" = rust ]" \
+	"Rust commits its Selection when mise exposes rustc"
+assert_true "grep -Fqx 'which rustc' '$RUST_CASE/mise.calls' && ! grep -Fqx 'which rust' '$RUST_CASE/mise.calls'" \
+	"Rust availability is probed through rustc rather than a nonexistent rust binary"
 
 # sb_install owns artifact installation, but setup owns Observed state. A
 # buggy/no-op installer returning zero must still not commit an absent command.


### PR DESCRIPTION
## Summary

- let mise-managed SDKs specify the executable used for observed-state validation
- validate Rust through `rustc` instead of the nonexistent `rust` executable
- cover successful Rust installation and Selection commit behavior

## Root cause

Squarebox passed the mise tool name to `mise which`. That works where the tool and executable share a name, but Rust installs `rustc` and `cargo`, not a `rust` binary.

## Validation

- all executable shell tests passed
- focused provisioning regression passed
- shell syntax checks passed
- PowerShell coverage remained platform-skipped because `pwsh` is unavailable
