### PR TITLE
fix: export the container default shell

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,6 +123,10 @@ jobs:
       - name: Shell config loads without errors
         run: docker run --rm -e DEVCONTAINER=1 squarebox:test bash --noprofile --rcfile /home/dev/.bashrc -ic 'command -v starship && command -v zoxide'
 
+      - name: Default shell is exported for child processes
+        run: |
+          test "$(docker run --rm squarebox:test env | awk -F= '$1 == "SHELL" { print $2 }')" = /bin/bash
+
       - name: Aliases resolve correctly
         run: |
           docker run --rm -e DEVCONTAINER=1 squarebox:test bash -lic '

--- a/Dockerfile
+++ b/Dockerfile
@@ -216,6 +216,9 @@ LABEL org.opencontainers.image.version="$SQUAREBOX_VERSION"
 # the running process is `dev` — identical to a plain `USER dev` image. PUID/
 # PGID are declared here so docker-compose / Unraid template UIs surface them.
 ENV HOME=/home/dev
+# Keep child processes launched via `docker exec` on the same interactive shell
+# path as the image's default CMD, even when the runtime does not export SHELL.
+ENV SHELL=/bin/bash
 ENV SQUAREBOX=1
 ENV PUID=1000
 ENV PGID=1000


### PR DESCRIPTION
## What changed

- Export `SHELL=/bin/bash` in the image, matching the default command.
- Add CI coverage that asserts the variable survives container startup.

## Why

Some container-launched tools choose their child shell from `SHELL`. Docker does not guarantee that variable is exported when using `docker exec`, so the image could fall back to `/bin/sh` even though Squarebox's default command and shell configuration are Bash-based. That bypasses `.bashrc` and Starship initialization.

## Validation

- `docker build -t squarebox:shell-env-test .`
- `docker run --rm squarebox:shell-env-test env` asserts `SHELL=/bin/bash`.
- `git diff --check`
