### PR TITLE
Suppress MOTD in Herdr panes

### DIFF
--- a/motd.sh
+++ b/motd.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 # squarebox MOTD — orange metallic banner with SDK info
 
+# Herdr creates a fresh interactive shell for every managed pane and exports
+# HERDR_ENV=1 there. The outer Box shell has already shown the MOTD, so avoid
+# repeating the full banner in every Herdr tab and split.
+[ "${HERDR_ENV:-}" = 1 ] && exit 0
+
 # Orange metallic: bright orange heading, muted orange date
 printf '\e[1;38;5;208m'
 toilet -f smblock --metal "squarebox"

--- a/tests/test-motd-startup-policy.sh
+++ b/tests/test-motd-startup-policy.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/toilet" <<'EOF'
+#!/usr/bin/env bash
+printf 'squarebox\n'
+EOF
+chmod +x "$TMP/bin/toilet"
+
+normal_output=$(HERDR_ENV=0 PATH="$TMP/bin:$PATH" bash "$ROOT/motd.sh")
+if [[ "$normal_output" != *squarebox* ]]; then
+	echo "FAIL: MOTD should render outside Herdr" >&2
+	exit 1
+fi
+
+herdr_output=$(HERDR_ENV=1 PATH="$TMP/bin:$PATH" bash "$ROOT/motd.sh")
+if [ -n "$herdr_output" ]; then
+	echo "FAIL: MOTD should be silent in a Herdr-managed pane" >&2
+	exit 1
+fi
+
+echo "PASS: MOTD renders normally and stays silent inside Herdr"


### PR DESCRIPTION
## What changed

- suppress the Squarebox MOTD when `HERDR_ENV=1`
- add a regression test proving the MOTD still renders outside Herdr and stays silent inside Herdr-managed panes

## Why

Herdr starts a fresh interactive shell for each pane. Squarebox invoked the MOTD unconditionally from interactive shell startup, causing the full banner to repeat in every Herdr tab and split.

## Impact

Regular Box terminals continue to show the MOTD. Herdr-managed panes now open without the repeated banner.

## Validation

- `tests/test-motd-startup-policy.sh`
- all executable `tests/test-*.sh` scripts
