### PR TITLE
Add YOLO aliases for supported AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@ Aliases
 | `gcad` | `git commit -a --amend` | Stage all and amend |
 | `lg` | `lazygit` | Launch lazygit (if installed) |
 | `claude-yolo` | `claude --dangerously-skip-permissions` | Claude without prompts |
+| `copilot-yolo` | `copilot --allow-all` | Copilot CLI without permission prompts |
 | `codex-yolo` | `codex --dangerously-bypass-approvals-and-sandbox` | Codex without prompts or sandboxing |
 | `gemini-yolo` | `gemini --approval-mode=yolo` | Gemini CLI without prompts |
 | `opencode-yolo` | `opencode --dangerously-skip-permissions` | OpenCode without prompts |

--- a/README.md
+++ b/README.md
@@ -384,7 +384,15 @@ Aliases
 | `gcad` | `git commit -a --amend` | Stage all and amend |
 | `lg` | `lazygit` | Launch lazygit (if installed) |
 | `claude-yolo` | `claude --dangerously-skip-permissions` | Claude without prompts |
+| `codex-yolo` | `codex --dangerously-bypass-approvals-and-sandbox` | Codex without prompts or sandboxing |
+| `gemini-yolo` | `gemini --approval-mode=yolo` | Gemini CLI without prompts |
 | `opencode-yolo` | `opencode --dangerously-skip-permissions` | OpenCode without prompts |
+| `omp-yolo` | `omp --approval-mode yolo` | Oh My Pi without prompts |
+
+The `*-yolo` aliases are generated only for selected AI tools that are
+installed. They disable that tool's normal approval prompts; `codex-yolo` also
+disables Codex's sandbox. Use them only in a workspace whose contents and
+commands you trust.
 
 ### Shared Keyboard Language (Experimental)
 

--- a/setup.sh
+++ b/setup.sh
@@ -752,6 +752,7 @@ printf '%s\n' "$ai_choice" > "$AI_CONFIG"
 			[ -z "$c_target" ] && c_target="$ai_tool"
 			case "$ai_tool" in
 				claude)   echo "alias claude-yolo='claude --dangerously-skip-permissions'" ;;
+				copilot)  echo "alias copilot-yolo='copilot --allow-all'" ;;
 				codex)    echo "alias codex-yolo='codex --dangerously-bypass-approvals-and-sandbox'" ;;
 				gemini)   echo "alias gemini-yolo='gemini --approval-mode=yolo'" ;;
 				opencode) echo "alias opencode-yolo='opencode --dangerously-skip-permissions'" ;;

--- a/setup.sh
+++ b/setup.sh
@@ -752,7 +752,10 @@ printf '%s\n' "$ai_choice" > "$AI_CONFIG"
 			[ -z "$c_target" ] && c_target="$ai_tool"
 			case "$ai_tool" in
 				claude)   echo "alias claude-yolo='claude --dangerously-skip-permissions'" ;;
+				codex)    echo "alias codex-yolo='codex --dangerously-bypass-approvals-and-sandbox'" ;;
+				gemini)   echo "alias gemini-yolo='gemini --approval-mode=yolo'" ;;
 				opencode) echo "alias opencode-yolo='opencode --dangerously-skip-permissions'" ;;
+				omp)     echo "alias omp-yolo='omp --approval-mode yolo'" ;;
 			esac
 		fi
 	done

--- a/tests/test-provision-state.sh
+++ b/tests/test-provision-state.sh
@@ -167,18 +167,25 @@ assert_true "grep -qx 'set -g mouse on' '$HOME_DIR/.config/tmux/tmux.conf'" "rec
 assert_true "[ \"\$(cat '$STATE/multiplexer')\" = tmux ]" "successful reconciliation preserves the saved Selection"
 assert_true "[ \"\$(cat '$STATE/editor-default')\" = fresh ] && grep -qx \"export EDITOR='fresh'\" '$HOME_DIR/.squarebox-editor-aliases'" "reconcile preserves a non-first default editor Selection"
 
-printf '#!/usr/bin/env bash\nexit 0\n' > "$BIN/codex"
+for ai_binary in copilot gemini codex pi omp; do
+	printf '#!/usr/bin/env bash\nexit 0\n' > "$BIN/$ai_binary"
+done
 printf '#!/usr/bin/env bash\nexit 0\n' > "$BIN/npm"
-printf '#!/usr/bin/env bash\nexit 0\n' > "$BIN/node"
+printf '#!/usr/bin/env bash\nif [ "${1:-}" = -p ]; then printf "22\\n"; else printf "v22.0.0\\n"; fi\n' > "$BIN/node"
 printf '#!/usr/bin/env bash\nexit 0\n' > "$BIN/mise"
-chmod +x "$BIN/codex" "$BIN/npm" "$BIN/node" "$BIN/mise"
-printf 'codex,removed-assistant\n' > "$STATE/ai-tool"
+chmod +x "$BIN/copilot" "$BIN/gemini" "$BIN/codex" "$BIN/pi" "$BIN/omp" \
+	"$BIN/npm" "$BIN/node" "$BIN/mise"
+printf 'copilot,gemini,codex,pi,omp,removed-assistant\n' > "$STATE/ai-tool"
 if HOME="$HOME_DIR" SQUAREBOX_STATE_DIR="$STATE" \
 	SQUAREBOX_TOOL_LIB="$FIXTURE_LIB" SQUAREBOX_TOOLS_YAML=/dev/null \
 	PATH="$BIN:$PATH" bash "$ROOT/setup.sh" --rerun ai >"$TMP/reconcile-ai.out" 2>"$TMP/reconcile-ai.err"; then
-	assert_true "[ \"\$(cat '$STATE/ai-tool')\" = codex ] && grep -q 'removing unsupported AI assistant' '$TMP/reconcile-ai.err'" "reconcile removes unsupported assistants from a saved Selection"
+	assert_true "[ \"\$(cat '$STATE/ai-tool')\" = copilot,gemini,codex,pi,omp ] && grep -q 'removing unsupported AI assistant' '$TMP/reconcile-ai.err'" "reconcile removes unsupported assistants from a saved Selection"
+	assert_true "grep -Fqx \"alias copilot-yolo='copilot --allow-all'\" '$HOME_DIR/.squarebox-ai-aliases' && grep -Fqx \"alias gemini-yolo='gemini --approval-mode=yolo'\" '$HOME_DIR/.squarebox-ai-aliases' && grep -Fqx \"alias codex-yolo='codex --dangerously-bypass-approvals-and-sandbox'\" '$HOME_DIR/.squarebox-ai-aliases' && grep -Fqx \"alias omp-yolo='omp --approval-mode yolo'\" '$HOME_DIR/.squarebox-ai-aliases'" "reconcile generates the supported AI YOLO aliases"
+	assert_true "! grep -Fq 'pi-yolo' '$HOME_DIR/.squarebox-ai-aliases'" "reconcile does not invent an unsupported Pi YOLO alias"
 else
 	not_ok "reconcile removes unsupported assistants from a saved Selection"
+	not_ok "reconcile generates the supported AI YOLO aliases"
+	not_ok "reconcile does not invent an unsupported Pi YOLO alias"
 fi
 
 printf 'set -g mouse off\n' > "$HOME_DIR/.config/tmux/tmux.conf"


### PR DESCRIPTION
## What changed

Add generated YOLO aliases for the supported AI agents that expose native approval-bypass modes:

- `copilot-yolo`
- `codex-yolo`
- `gemini-yolo`
- `omp-yolo`

Claude and OpenCode aliases remain unchanged. Pi is intentionally not given a
`pi-yolo` alias because its current CLI does not expose an equivalent all-tools
approval-bypass mode.

## Why

Squarebox already provides `claude-yolo` and `opencode-yolo`, but users of
Codex, Gemini CLI, and Oh My Pi had to remember each tool's native flag.

## Safety

The aliases are explicit and opt-in. `codex-yolo` also disables Codex
sandboxing, so the README calls that out alongside the general trust warning.

## Validation

- `bash -n setup.sh`
- `git diff --check`
- Verified the generated alias mappings and README entries match.
