### PR TITLE
docs: sync release and roadmap guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## Unreleased (v1.3 candidate)
+
+### Added
+
+- Explicit, transactional conversion between native PowerShell and Git Bash
+  lifecycle adapters without changing the Box, image, Workspace, or Managed home.
+- Recoverable Box replacement: handled late failures restore the prior runnable
+  Box and its recorded Install identity.
+- A mechanically verified, shared Install identity schema contract for the Bash
+  and PowerShell adapters.
+- Trust-explicit `*-yolo` aliases for installed AI assistants.
+
+### Changed
+
+- Herdr uses terminal-safe direct shortcuts while retaining `F12` as a
+  compatibility prefix.
+- The selected default shell is exported consistently to child processes.
+
+See the [v1.3 migration guide](docs/releases/v1.3.0.md).
+
+## v1.2.3 — 2026-08-05
+
+- Suppressed Squarebox's MOTD inside Herdr-managed panes.
+
+## v1.2.2 — 2026-08-05
+
+- Fixed Rust SDK detection so an installed toolchain is not repeatedly
+  reconciled as missing.
+
 ## v1.2.1 — 2026-07-31
 
 v1.2.0 was built as a draft Candidate but was never published after final

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ running AI agents, and a persistent terminal environment for remote development.
 One-line install, interactive first-run setup, sensible defaults (thanks
 [omarchy](https://omarchy.org)).
 
-Preparing an existing installation for v1.2? Read the
-[migration guide](docs/releases/v1.2.1.md) and [changelog](CHANGELOG.md).
+Upgrading an existing installation? Read the relevant
+[migration guide](docs/releases/) and [changelog](CHANGELOG.md).
 
 ![squarebox first-run setup](demo/squarebox-setup.gif)
 *(Actual setup may involve more staring at the screen.)*

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,30 +1,11 @@
 # Roadmap
 
-## v1.2.1 release gate
+## Current priorities
 
-- Pass every assertion in `scripts/e2e-required.tsv` against one immutable Candidate digest.
-- Keep platform-specific manual qualification optional; automated Candidate
-  Evidence is the release gate.
-- `v1.2.1-rc5` completed the automatic publication rehearsal.
-- Keep GitHub immutable Releases enabled, keep the no-bypass `v*` update and
-  deletion ruleset active, and verify the stable/prerelease environment
-  protections before creating a final tag.
-- Create the immutable `v1.2.1` tag so CI builds one final Candidate and
-  prepares its signed assets as a non-discoverable draft, then approve the
-  protected stable environment to publish those bytes without rebuilding.
-  Do not retarget the final tag if qualification fails; fix forward with a new
-  version.
-- Verify the final Candidate identity, attestation, aliases, and non-rewind
-  behavior in issue #131.
-
-## After v1.1
-
-- **Install identity schema consolidation** — replace four regression-locked
-  adapter validators with one authoritative cross-language contract (#106).
-- **Windows SSH and adapter migration** — design native OpenSSH-agent
-  forwarding and a safe Git Bash/PowerShell identity migration path (#107).
-- **Lifecycle replacement recovery** — restore a coherent runnable prior Box,
-  image, source, and state after handled late rebuild failures (#108).
+- **Native Windows SSH-agent relay** — prototype a safe bridge for Docker
+  Desktop and Podman ([#160](https://github.com/SquareWaveSystems/squarebox/issues/160)).
+- **Codex app-server state** — restore opt-in state safely after Box restart
+  ([#134](https://github.com/SquareWaveSystems/squarebox/issues/134)).
 - **Learn mode redesign** — opt-in lessons with corrected versioned content,
   binary-based capability checks, an explicit privacy contract, and no command
   logging without informed consent.
@@ -39,3 +20,8 @@
   around long-running assistant commands.
 - **Native platform depth** — improve platform adapters when concrete defects
   justify the work; do not maintain a standing manual qualification matrix.
+
+Release qualification remains assertion-driven: every required ID in
+`scripts/e2e-required.tsv` must pass against one immutable Candidate digest.
+Platform-specific manual checks in `uat-checklist.md` are optional follow-up,
+not an inferred release gate.

--- a/uat-checklist.md
+++ b/uat-checklist.md
@@ -1,9 +1,9 @@
-# Squarebox v1.2.1 release checks
+# Squarebox release checks
 
 Automated release assertions are defined in `scripts/e2e-required.tsv` and
 reported from exact Evidence by `.github/workflows/e2e.yml`. That automated
-Candidate workflow is the v1.2.1 release gate. A per-platform manual
-qualification matrix is not required for this release.
+Candidate workflow is the release gate. A per-platform manual qualification
+matrix is not required.
 
 Native PowerShell remains a separate adapter and does not claim `SSH_AUTH_SOCK` forwarding;
 adapter boundaries are covered by automated/static checks.
@@ -21,10 +21,6 @@ adapter boundaries are covered by automated/static checks.
 
 Record the Candidate version, source SHA, image digest, and result for any
 optional follow-up run.
-
-Release tracker: [v1.2.1 #125](https://github.com/SquareWaveSystems/squarebox/issues/125).
-Optional primary-Linux follow-up: [#126](https://github.com/SquareWaveSystems/squarebox/issues/126).
-Final Candidate and publication: [#131](https://github.com/SquareWaveSystems/squarebox/issues/131).
 
 ## Optional primary-Linux follow-up
 
@@ -44,7 +40,7 @@ Final Candidate and publication: [#131](https://github.com/SquareWaveSystems/squ
 - [ ] Download the non-discoverable draft assets with authenticated `gh release download` and verify their hashes and Cosign identity signature
 - [ ] Run the automated Candidate suite and confirm all required Evidence passes
 - [ ] Confirm stable installers cannot discover the Release until all gates pass
-- [ ] Record the qualification evidence and explicit promote/no-promote decision in [issue #131](https://github.com/SquareWaveSystems/squarebox/issues/131)
+- [ ] Record the qualification evidence and explicit promote/no-promote decision in the release tracker
 - [ ] Approve the waiting `stable-release` environment deployment to publish the tested Candidate without rebuilding different image bytes
 - [ ] After publication, run `gh release verify <tag>` and confirm GitHub reports a valid immutable-Release attestation
 - [ ] Confirm GitHub Release and GHCR `latest` identify the greatest published stable version


### PR DESCRIPTION
## Summary

- bring the changelog up to date with v1.2.2, v1.2.3, and the current v1.3 Candidate work
- replace completed v1.2 roadmap items with the current open priorities
- make the reusable release checklist version-neutral and remove completed tracker links
- point upgrades to the release-guide index instead of one stale version

## Scope

Documentation only. Historical release guides and ADRs are unchanged.

## Validation

- `git diff --check`
- all executable `tests/test-*.sh` tests